### PR TITLE
Fixing tests after project rename

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements/tests.txt
 commands =
-    py.test -s -v
+    py.test -s -v {envsitepackagesdir}/frontera
 
 [testenv:flake8]
 changedir = {toxinidir}


### PR DESCRIPTION
Just passing explicit module path to py.test.