### PR TITLE
Quick fix of premature Scrapy spider closing on cold start

### DIFF
--- a/docs/source/topics/frontera-settings.rst
+++ b/docs/source/topics/frontera-settings.rst
@@ -192,7 +192,9 @@ Default: ``0.0``
 When backend has no requests to fetch, this delay helps to exhaust the rest of the buffer without hitting
 backend on every request. Increase it if calls to your backend is taking a lot of time, and decrease if you need a fast
 spider bootstrap from seeds. Keep in mind, this setting prevents Frontera from fetching new requests from backend,
-therefore causing Scrapy spider to close prematurely.
+therefore causing Scrapy spider to close prematurely. To prevent spider from closing you can either use DontCloseSpider
+exception raising from `spider_idle <http://doc.scrapy.org/en/latest/topics/signals.html#spider-idle>`_ signal, or
+keeping spider queue always full.
 
 
 Built-in fingerprint middleware settings

--- a/docs/source/topics/frontera-settings.rst
+++ b/docs/source/topics/frontera-settings.rst
@@ -187,11 +187,12 @@ overused. This affects only Scrapy scheduler."
 DELAY_ON_EMPTY
 --------------
 
-Default: ``30.0``
+Default: ``0.0``
 
 When backend has no requests to fetch, this delay helps to exhaust the rest of the buffer without hitting
 backend on every request. Increase it if calls to your backend is taking a lot of time, and decrease if you need a fast
-spider bootstrap from seeds.
+spider bootstrap from seeds. Keep in mind, this setting prevents Frontera from fetching new requests from backend,
+therefore causing Scrapy spider to close prematurely.
 
 
 Built-in fingerprint middleware settings

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -14,7 +14,7 @@ MAX_REQUESTS = 0
 MAX_NEXT_REQUESTS = 0
 AUTO_START = True
 OVERUSED_SLOT_FACTOR = 5.0
-DELAY_ON_EMPTY = 30.0
+DELAY_ON_EMPTY = 0.0
 
 #--------------------------------------------------------
 # Fingerprints mw


### PR DESCRIPTION
This isn't a complete, well thought-out solution, rather quick fix of https://github.com/scrapinghub/frontera/issues/33

In short I set default value of DELAY_ON_EMPTY to 0.0, to prevent delays on get_next_request calls and allowing it to hit DB as many times as needed, by default.
Users who make crawler focused on particular website, probably doesn't care about hitting DB too much, because DB will be small, likely. So the intention is to save their time, making Frontera work out of the box. For those who cares about DB load, this option is still available.