### PR TITLE
Keep metadata when converting scrapy Response objects to Frontera Response objects

### DIFF
--- a/frontera/contrib/scrapy/converters.py
+++ b/frontera/contrib/scrapy/converters.py
@@ -47,11 +47,13 @@ class ResponseConverter(BaseResponseConverter):
     @classmethod
     def to_frontier(cls, response):
         """response: Scrapy > Frontier"""
-        return FrontierResponse(url=response.url,
-                                status_code=response.status,
-                                headers=response.headers,
-                                body=response.body,
-                                request=response.meta['frontier_request'])
+        frontier_response = FrontierResponse(url=response.url,
+                                             status_code=response.status,
+                                             headers=response.headers,
+                                             body=response.body,
+                                             request=response.meta['frontier_request'])
+        frontier_response.meta.update(response.meta)
+        return frontier_response
 
     @classmethod
     def from_frontier(cls, response):


### PR DESCRIPTION
This is necessary if, for example, some spider middleware adds some kind of relevance score to a crawled page inside the Response object.