### PR TITLE
Empty scrapy_meta dict created empty by default inside frontier Reque…

### DIFF
--- a/frontera/core/models.py
+++ b/frontera/core/models.py
@@ -25,7 +25,7 @@ class Request(FrontierObject):
         self._method = str(method).upper()
         self._headers = headers or {}
         self._cookies = cookies or {}
-        self._meta = meta or {}
+        self._meta = meta or {'scrapy_meta': {}}
 
     @property
     def url(self):

--- a/frontera/tests/test_scrapy.py
+++ b/frontera/tests/test_scrapy.py
@@ -3,6 +3,7 @@
 from frontera.contrib.scrapy.converters import RequestConverter, ResponseConverter
 from scrapy.http.request import Request as ScrapyRequest
 from scrapy.http.response import Response as ScrapyResponse
+from frontera.core.models import Request as FrontierRequest
 
 
 class TestSpider(object):
@@ -53,3 +54,7 @@ def test_request_response_converters():
     assert response_converted.url == url
     assert response_converted.status == 200
     assert response_converted.headers['TestHeader'] == 'Test value'
+
+    frontier_request = FrontierRequest(url)
+    request_converted = rc.from_frontier(frontier_request)
+    assert frontier_request.url == url


### PR DESCRIPTION
RequestConverter expects that Requests originating from Frontier contain an scrapy_meta dict inside the meta dict. The most correct way of ensuring this is creating a default empty dict at the moment of Request creation.