### PR TITLE
allow to update frontera settings from spider

### DIFF
--- a/frontera/contrib/scrapy/schedulers/frontier.py
+++ b/frontera/contrib/scrapy/schedulers/frontier.py
@@ -76,10 +76,9 @@ class FronteraScheduler(Scheduler):
         self.stats_manager = StatsManager(crawler.stats)
         self._pending_requests = deque()
         self.redirect_enabled = crawler.settings.get('REDIRECT_ENABLED')
-        settings = ScrapySettingsAdapter(crawler.settings)
-        self.frontier = ScrapyFrontierManager(settings)
-        self._delay_on_empty = self.frontier.manager.settings.get('DELAY_ON_EMPTY')
         self._delay_next_call = 0.0
+        self.frontier = None
+        self._delay_on_empty = None
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -119,6 +118,11 @@ class FronteraScheduler(Scheduler):
         self.stats_manager.add_request_error(error_code)
 
     def open(self, spider):
+        settings = ScrapySettingsAdapter(spider.crawler.settings)
+        settings.set_from_dict(getattr(spider, 'frontera_settings', {}))
+        self.frontier = ScrapyFrontierManager(settings)
+        self._delay_on_empty = self.frontier.manager.settings.get('DELAY_ON_EMPTY')
+
         self.frontier.set_spider(spider)
         log.msg('Starting frontier', log.INFO)
         if not self.frontier.manager.auto_start:


### PR DESCRIPTION
Motivation:

Scrapy spiders are very frequently configured dynamically per job, so we need a mean to configure frontera settings after spider initialization, which is where we have access to spider arguments.

Dash API does not support passing of settings per job but also, even if in future would be possible, that alone does not allow dynamic programmatic configuration inside the spider. Usually settings are low level while spider arguments are high level, so we need to compute optimal settings from the arguments passed. Of course this computation could be done from the script that schedules the spider, but it is usually spider dependent, and spider code is the best place to put spider dependent logic.

So this patch is very simple, allows lot of flexibility on spider development, does not changes settings on the fly (settings are defined before frontier instantiation) and avoids the dependence on an API to pass settings per job.