### PR TITLE
Converter pass dont_filter

### DIFF
--- a/frontera/contrib/scrapy/converters.py
+++ b/frontera/contrib/scrapy/converters.py
@@ -28,6 +28,7 @@ class RequestConverter(BaseRequestConverter):
             'scrapy_errback': eb,
             'scrapy_meta': scrapy_request.meta,
             'origin_is_frontier': True,
+            'dont_filter': scrapy_request.dont_filter,
         }
         return FrontierRequest(url=scrapy_request.url,
                                method=scrapy_request.method,


### PR DESCRIPTION
I believe we should pass dont_filter from Scrapy Request to Frontera Request, in order to have control over dupefilter behavior per request. Currently, Frontera middleware dupefilter checks for dont_filter, but there is no way to set it from the spider.