### PR TITLE
Import tldextract lazily

### DIFF
--- a/docs/source/topics/frontera-settings.rst
+++ b/docs/source/topics/frontera-settings.rst
@@ -225,6 +225,21 @@ Default: ``frontera.utils.fingerprint.sha1``
 The function used to calculate the ``domain`` fingerprint.
 
 
+.. setting:: TLDEXTRACT_DOMAIN_INFO
+
+TLDEXTRACT_DOMAIN_INFO
+----------------------
+
+Default: ``False``
+
+If set to ``True``, will use `tldextract`_ to attach extra domain information
+(second-level, top-level and subdomain) to meta field (see :ref:`frontier-objects-additional-data`).
+
+
+.. _tldextract: https://pypi.python.org/pypi/tldextract
+
+
+
 Default settings
 ================
 

--- a/docs/source/topics/frontier-objects.rst
+++ b/docs/source/topics/frontier-objects.rst
@@ -50,6 +50,9 @@ An example of a generated fingerprint for a :class:`Request <frontera.core.model
     '198d99a8b2284701d6c147174cd69a37a7dea90f'
 
 
+.. _frontier-objects-additional-data:
+
+
 Adding additional data to objects
 =================================
 

--- a/frontera/contrib/middlewares/domain.py
+++ b/frontera/contrib/middlewares/domain.py
@@ -4,9 +4,6 @@ from frontera.core.components import Middleware
 from frontera.utils.url import parse_domain_from_url_fast, parse_domain_from_url
 
 
-
-
-
 class DomainMiddleware(Middleware):
     """
     This :class:`Middleware <frontera.core.components.Middleware>` will add a ``domain`` info field for every

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -24,6 +24,11 @@ URL_FINGERPRINT_FUNCTION = 'frontera.utils.fingerprint.sha1'
 DOMAIN_FINGERPRINT_FUNCTION = 'frontera.utils.fingerprint.sha1'
 
 #--------------------------------------------------------
+# Domain mw
+#--------------------------------------------------------
+TLDEXTRACT_DOMAIN_INFO = False
+
+#--------------------------------------------------------
 # Logging
 #--------------------------------------------------------
 LOGGER = 'frontera.logger.FrontierLogger'

--- a/frontera/tests/test_domain_mware.py
+++ b/frontera/tests/test_domain_mware.py
@@ -1,0 +1,63 @@
+import unittest
+from frontera.contrib.middlewares.domain import DomainMiddleware
+from frontera.core.manager import FrontierManager
+from frontera.core.models import Request
+
+
+class FakeManager(object):
+    settings = {}
+    test_mode = False
+
+
+class DomainMiddlewareTest(unittest.TestCase):
+    def setUp(self):
+        self.fake_manager = FakeManager()
+
+    def test_create(self):
+        DomainMiddleware(self.fake_manager)
+
+    def test_should_parse_domain_info(self):
+        seeds = [
+            Request('http://example.com'),
+            Request('https://www.google.com'),
+        ]
+
+        mware = DomainMiddleware(self.fake_manager)
+        result = mware.add_seeds(seeds)
+
+        self.assertEquals(len(result), len(seeds))
+
+        for r in result:
+            self.assertIn('domain', r.meta, 'Missing domain info for %r' % r)
+
+        expected = [
+            {'name': 'example.com', 'netloc': 'example.com', 'scheme': 'http',
+             'sld': '', 'subdomain': '', 'tld': ''},
+            {'name': 'www.google.com', 'netloc': 'www.google.com', 'scheme': 'https',
+             'sld': '', 'subdomain': '', 'tld': ''},
+        ]
+        self.assertEquals(expected, [r.meta['domain'] for r in result])
+
+    def test_should_parse_tldextract_extra_domain_info(self):
+        seeds = [
+            Request('http://example.com'),
+            Request('https://www.google.com'),
+        ]
+
+        self.fake_manager.settings = {'TLDEXTRACT_DOMAIN_INFO': True}
+
+        mware = DomainMiddleware(self.fake_manager)
+        result = mware.add_seeds(seeds)
+
+        self.assertEquals(len(result), len(seeds))
+
+        for r in result:
+            self.assertIn('domain', r.meta, 'Missing domain info for %r' % r)
+
+        expected = [
+            {'name': 'example.com', 'netloc': 'example.com', 'scheme': 'http',
+             'sld': 'example', 'subdomain': '', 'tld': 'com'},
+            {'name': 'google.com', 'netloc': 'www.google.com', 'scheme': 'https',
+             'sld': 'google', 'subdomain': 'www', 'tld': 'com'},
+        ]
+        self.assertEquals(expected, [r.meta['domain'] for r in result])

--- a/frontera/utils/url.py
+++ b/frontera/utils/url.py
@@ -4,7 +4,6 @@ import cgi
 import hashlib
 from six import moves
 from w3lib.util import unicode_to_str
-import tldextract
 
 
 # Python 2.x urllib.always_safe become private in Python 3.x;
@@ -39,6 +38,7 @@ def parse_domain_from_url(url):
      https://google.es/mail    google.es           google.es       https     google      es
     -------------------------------------------------------------------------------------------------------
     """
+    import tldextract
     extracted = tldextract.extract(url)
     scheme, _, _, _, _, _ = parse_url(url)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 six>=1.8.0
 w3lib>=1.10.0
-tldextract>=1.5.1
 SQLAlchemy>=0.9.8

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,3 +3,4 @@ MySQL-python>=1.2.5
 PyMySQL>=0.6.3
 psycopg2>=2.5.4
 scrapy>=0.24
+-r tldextract.txt

--- a/requirements/tldextract.txt
+++ b/requirements/tldextract.txt
@@ -1,0 +1,1 @@
+tldextract>=1.5.1

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     install_requires=[
         'six>=1.8.0',
         'w3lib>=1.10.0',
-        'tldextract>=1.5.1',
         'SQLAlchemy>=0.9.8'
     ],
     extras_require={
@@ -49,6 +48,9 @@ setup(
         'logging': [
             "colorlog>=2.4.0",
         ],
+        'tldextract': [
+            'tldextract>=1.5.1',
+        ]
     },
     tests_require=[
         "pytest>=2.6.4",

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "MySQL-python>=1.2.5",
         "PyMySQL>=0.6.3",
         "psycopg2>=2.5.4",
-        "scrapy>=0.24"
+        "scrapy>=0.24",
+        "tldextract>=1.5.1",
     ]
 )


### PR DESCRIPTION
This makes tldextract optional for code that doesn't use the standard URL parsing with `parse_domain_from_url(url)`.