### PR TITLE
Add body and dont_filter to Frontera request

### DIFF
--- a/frontera/contrib/scrapy/converters.py
+++ b/frontera/contrib/scrapy/converters.py
@@ -41,8 +41,10 @@ class RequestConverter(BaseRequestConverter):
         return FrontierRequest(url=scrapy_request.url,
                                method=scrapy_request.method,
                                headers=scrapy_request.headers,
+                               body=scrapy_request.body,
                                cookies=cookies,
-                               meta=meta)
+                               meta=meta,
+                               dont_filter=scrapy_request.dont_filter)
 
     def from_frontier(self, frontier_request):
         """request: Frontier > Scrapy"""
@@ -59,9 +61,10 @@ class RequestConverter(BaseRequestConverter):
                              errback=eb,
                              method=frontier_request.method,
                              headers=frontier_request.headers,
+                             body=frontier_request.body,
                              cookies=frontier_request.cookies,
                              meta=meta,
-                             dont_filter=True)
+                             dont_filter=frontier_request.dont_filter)
 
 
 class ResponseConverter(BaseResponseConverter):

--- a/frontera/core/models.py
+++ b/frontera/core/models.py
@@ -13,19 +13,24 @@ class Request(FrontierObject):
     :class:`Response <frontera.core.models.Response>` object when crawled.
 
     """
-    def __init__(self, url, method='GET', headers=None, cookies=None, meta=None):
+    def __init__(self, url, method='GET', headers=None, body=None, cookies=None, meta=None,
+                 dont_filter=False):
         """
         :param string url: URL to send.
         :param string method: HTTP method to use.
+        :param string body: encoded Body for request
         :param dict headers: dictionary of headers to send.
         :param dict cookies: dictionary of cookies to attach to this request.
         :param dict meta: dictionary that contains arbitrary metadata for this request.
+        :param bool dont_filter: indicates that this request should not be filtered by backend
         """
         self._url = url
         self._method = str(method).upper()
         self._headers = headers or {}
         self._cookies = cookies or {}
         self._meta = meta or {'scrapy_meta': {}}
+        self._body = body
+        self._dont_filter = dont_filter
 
     @property
     def url(self):
@@ -50,6 +55,13 @@ class Request(FrontierObject):
         return self._headers
 
     @property
+    def body(self):
+        """
+        Body to attach to this request.
+        """
+        return self._body
+
+    @property
     def cookies(self):
         """
         Dictionary of cookies to attach to this request.
@@ -64,6 +76,10 @@ class Request(FrontierObject):
         on the components you have enabled.
         """
         return self._meta
+
+    @property
+    def dont_filter(self):
+        return self._dont_filter
 
     def __str__(self):
         return "<%s at 0x%0x %s>" % (type(self).__name__, id(self), self.url)

--- a/frontera/tests/test_heap.py
+++ b/frontera/tests/test_heap.py
@@ -1,0 +1,49 @@
+import unittest
+from mock import ANY
+from frontera.utils.heap import Heap, HeapObjectWrapper
+from frontera.core.models import Request
+
+# higher priority =>smaller value, higher in heap
+def compare_request(first, second):
+    return first.meta.get('priority',0) < second.meta.get('priority',0)
+
+req1 = Request(ANY, meta={'priority':1})
+req2 = Request(ANY, meta={'priority':2})
+req3 = Request(ANY, meta={'priority':3})
+
+
+class HeapTest(unittest.TestCase):
+
+    def setUp(self):
+        self.heap = Heap(compare_request)
+
+    def test_push(self):
+        self.heap.push(req1)
+        self.heap.push(req2)
+        assert len(self.heap) == 2
+
+    def test_pop0_as_pop0(self):
+        print len(self.heap)
+        self.heap.push(req1)
+        req = self.heap.pop(0)
+        assert len(req) == 1
+        assert req[0] == req1
+        self.heap.push(req1)
+        req = self.heap.pop(1)
+        assert len(req) == 1
+        assert req[0] == req1
+
+    def test_pop_smallest_in_heap(self):
+        self.heap.push(req1)
+        self.heap.push(req2)
+        req = self.heap.pop(0)
+        assert req[0] == req2
+
+    def test_push_limit(self):
+        self.heap = Heap(compare_request,limit=2)
+        self.heap.push(req1)
+        self.heap.push(req2)
+        p = self.heap.push(req3)
+        assert p == req2
+        assert len(self.heap) == 2
+        assert self.heap.pop(2) == [req3,req1]

--- a/frontera/utils/heap.py
+++ b/frontera/utils/heap.py
@@ -39,14 +39,23 @@ class HeapObjectWrapper(object):
     def __str__(self):
         return str(self.obj)
 
-
+# When limit is specified, it is a bounded heap and push will use heapreplace and return poped element
+# Ignoring the fact that the returned element should actually never be discarded
 class Heap(object):
-    def __init__(self, compare_function):
+    def __init__(self, compare_function,limit=0):
         self.heap = []
         self._compare_function = compare_function
+        self.limit = limit
+
+    def __len__(self):
+        return self.heap.__len__()
 
     def push(self, obj):
-        heapq.heappush(self.heap, HeapObjectWrapper(obj, self._compare_function))
+        wrapped = HeapObjectWrapper(obj, self._compare_function)
+        if self.__len__() >= self.limit > 0:
+            return heapq.heapreplace(self.heap,wrapped).obj
+        else:
+            heapq.heappush(self.heap, wrapped)
 
     def pop(self, n):
         pages = []


### PR DESCRIPTION
Given frontera support POST/PUT, it make sense to have the body in request. 
Also added `dont_filter` to reuse the convention that such request should not be filtered by backend (even if it is duplicated)

What is the major idea of creating another Request object specialized for Frontera?
here we assumed encoding done by scrapy, which may need further fine tune. 
