### PR TITLE
Do not enforce AWS keys in settings for the S3SeedLoader

### DIFF
--- a/frontera/contrib/scrapy/middlewares/seeds/s3.py
+++ b/frontera/contrib/scrapy/middlewares/seeds/s3.py
@@ -15,7 +15,7 @@ class S3SeedLoader(FileSeedLoader):
         self.bucket_keys_prefix = u.path.lstrip('/')
         self.s3_aws_access_key = settings.get('SEEDS_AWS_ACCESS_KEY')
         self.s3_aws_secret_key = settings.get('SEEDS_AWS_SECRET_ACCESS_KEY')
-        
+
     def load_seeds(self):
         conn = connect_s3(self.s3_aws_access_key,
                           self.s3_aws_secret_key)

--- a/frontera/contrib/scrapy/middlewares/seeds/s3.py
+++ b/frontera/contrib/scrapy/middlewares/seeds/s3.py
@@ -15,9 +15,7 @@ class S3SeedLoader(FileSeedLoader):
         self.bucket_keys_prefix = u.path.lstrip('/')
         self.s3_aws_access_key = settings.get('SEEDS_AWS_ACCESS_KEY')
         self.s3_aws_secret_key = settings.get('SEEDS_AWS_SECRET_ACCESS_KEY')
-        if not self.s3_aws_access_key or not self.s3_aws_secret_key:
-            raise NotConfigured
-
+        
     def load_seeds(self):
         conn = connect_s3(self.s3_aws_access_key,
                           self.s3_aws_secret_key)


### PR DESCRIPTION
`S3SeedLoader` enforces to define the AWS keys through the settings, but `boto` is able to detect them from the default AWS settings.

Not having to specify the AWS keys is very convenient when using the AWS IAM Temporary Security Credentials through the AWS Security Token Service, where AWS keys are generated automatically and for a short period of time. 

More info here: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html