### PR TITLE
SPIDER_PARTITION_ID setting is coming as str

### DIFF
--- a/frontera/contrib/backends/remote/messagebus.py
+++ b/frontera/contrib/backends/remote/messagebus.py
@@ -16,7 +16,7 @@ class MessageBusBackend(Backend):
         self._decoder = Decoder(manager.request_model, manager.response_model)
         self.spider_log_producer = self.mb.spider_log().producer()
         spider_feed = self.mb.spider_feed()
-        self.partition_id = settings.get('SPIDER_PARTITION_ID')
+        self.partition_id = int(settings.get('SPIDER_PARTITION_ID'))
         self.consumer = spider_feed.consumer(partition_id=self.partition_id)
         self._get_timeout = float(settings.get('KAFKA_GET_TIMEOUT'))
         self._buffer = OverusedBuffer(self._get_next_requests,


### PR DESCRIPTION
It comes as integer when set with Python modules, and as `str` when set from Scrapy cmd line settings. To prevent, running forward I propose to convert value of this setting to integer to handle all these cases and check for wrong value.