### PR TITLE
fix for issue #116

### DIFF
--- a/docs/source/topics/scrapy-integration.rst
+++ b/docs/source/topics/scrapy-integration.rst
@@ -101,7 +101,7 @@ Writing Scrapy spider
 
 Spider logic
 ------------
-Creation of basic Scrapy spider is described at `Frontier at a glance`_ page.
+Creation of basic Scrapy spider is described at `Quick start single process`_ page.
 
 It's also a good practice to prevent spider from closing because of insufficiency of queued requests transport:::
 
@@ -156,7 +156,7 @@ Auto throttling and concurrency settings for polite and responsible crawling:::
 Check also `Scrapy broad crawling`_ recommendations.
 
 
-.. _`Frontier at a glance`: http://frontera.readthedocs.org/en/latest/topics/frontier-at-a-glance.html
+.. _`Quick start single process`: http://frontera.readthedocs.org/en/latest/topics/quick-start-single.html
 .. _`Scrapy broad crawling`: http://doc.scrapy.org/en/master/topics/broad-crawls.html
 
 


### PR DESCRIPTION
https://github.com/scrapinghub/frontera/issues/116
'frontier at a glance' page is almost identical to 'Quick start single process'. So just changed that link. You can compare the following links and see for yourself.
http://frontera.readthedocs.org/en/latest/topics/quick-start-single.html
http://frontera.readthedocs.org/en/v0.3.0/topics/frontier-at-a-glance.html (found only v0.3.0 docs)