### PR TITLE
utils.async unit tests and minor fix

### DIFF
--- a/frontera/tests/test_utils_async.py
+++ b/frontera/tests/test_utils_async.py
@@ -58,7 +58,8 @@ class TestListenTCP(object):
 
     def test_listen_tcp_integer(self):
         reactor = MemoryReactor()
-        listen_tcp(self.port, self.host, Factory, reactor=reactor)
+        result = listen_tcp(self.port, self.host, Factory, reactor=reactor)
+        assert result.getHost().port == self.port
         assert reactor.tcpServers[0][0] == self.port
 
     def test_listen_tcp_invalid_port_range(self):
@@ -69,16 +70,19 @@ class TestListenTCP(object):
 
     def test_listen_tcp_default(self):
         reactor = MemoryReactor()
-        listen_tcp([], self.host, Factory, reactor=reactor)
+        result = listen_tcp([], self.host, Factory, reactor=reactor)
+        assert result.getHost().port == 0
         assert reactor.tcpServers[0][0] == 0
 
     def test_listen_tcp_range_length_one(self):
         reactor = MemoryReactor()
-        listen_tcp([self.port], self.host, Factory, reactor=reactor)
+        result = listen_tcp([self.port], self.host, Factory, reactor=reactor)
+        assert result.getHost().port == self.port
         assert reactor.tcpServers[0][0] == self.port
 
     def test_listen_tcp_full_range(self):
         reactor = MemoryReactor()
-        listen_tcp(self.portrange, self.host, Factory, reactor=reactor)
+        result = listen_tcp(self.portrange, self.host, Factory, reactor=reactor)
+        assert self.portrange[0] <= result.getHost().port <= self.portrange[1]
         assert len(reactor.tcpServers) == 1
         assert self.portrange[0] <= reactor.tcpServers[0][0] <= self.portrange[1]

--- a/frontera/tests/test_utils_async.py
+++ b/frontera/tests/test_utils_async.py
@@ -54,7 +54,7 @@ class TestListenTCP(object):
 
     host = '127.0.0.1'
     port = 6023
-    portrange = [6023,6073]
+    portrange = [6023, 6073]
 
     def test_listen_tcp_integer(self):
         reactor = MemoryReactor()

--- a/frontera/tests/test_utils_async.py
+++ b/frontera/tests/test_utils_async.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import pytest
+from twisted.test.proto_helpers import MemoryReactor
+from twisted.internet.protocol import Factory
+from twisted.internet.task import Clock
+from frontera.utils.async import CallLaterOnce, listen_tcp
+
+
+class TestCallLaterOnce(object):
+
+    called = 0
+
+    def call_function(self):
+        self.called += 1
+
+    def test_call_later_once(self):
+        self.called = 0
+        reactor = Clock()
+        call = CallLaterOnce(self.call_function, reactor=reactor)
+        call.schedule(delay=1)
+        reactor.advance(1)
+        assert self.called == 1
+
+    def test_call_later_twice(self):
+        self.called = 0
+        reactor = Clock()
+        call = CallLaterOnce(self.call_function, reactor=reactor)
+        call.schedule(delay=1)
+        reactor.advance(1)
+        call.schedule(delay=1)
+        reactor.advance(1)
+        assert self.called == 2
+
+    def test_call_later_twice_already_scheduled(self):
+        self.called = 0
+        reactor = Clock()
+        call = CallLaterOnce(self.call_function, reactor=reactor)
+        call.schedule(delay=1)
+        call.schedule(delay=2)
+        reactor.advance(2)
+        assert self.called == 1
+
+    def test_call_later_cancel(self):
+        self.called = 0
+        reactor = Clock()
+        call = CallLaterOnce(self.call_function, reactor=reactor)
+        call.schedule(delay=1)
+        call.cancel()
+        reactor.advance(1)
+        assert self.called == 0
+
+
+class TestListenTCP(object):
+
+    host = '127.0.0.1'
+    port = 6023
+    portrange = [6023,6073]
+
+    def test_listen_tcp_integer(self):
+        reactor = MemoryReactor()
+        listen_tcp(self.port, self.host, Factory, reactor=reactor)
+        assert reactor.tcpServers[0][0] == self.port
+
+    def test_listen_tcp_invalid_port_range(self):
+        reactor = MemoryReactor()
+        with pytest.raises(Exception) as info:
+            listen_tcp([1, 2, 3], self.host, Factory, reactor=reactor)
+        assert info.value.message == 'invalid portrange: [1, 2, 3]'
+
+    def test_listen_tcp_default(self):
+        reactor = MemoryReactor()
+        listen_tcp([], self.host, Factory, reactor=reactor)
+        assert reactor.tcpServers[0][0] == 0
+
+    def test_listen_tcp_range_length_one(self):
+        reactor = MemoryReactor()
+        listen_tcp([self.port], self.host, Factory, reactor=reactor)
+        assert reactor.tcpServers[0][0] == self.port
+
+    def test_listen_tcp_full_range(self):
+        reactor = MemoryReactor()
+        listen_tcp(self.portrange, self.host, Factory, reactor=reactor)
+        assert len(reactor.tcpServers) == 1
+        assert self.portrange[0] <= reactor.tcpServers[0][0] <= self.portrange[1]


### PR DESCRIPTION
I have added some tests for the two functions in utils.async. A small modification to listen_tcp - I have changed the check `not list` to `is int` because this is more accurate as the argument to `listenTCP` must be integral. Also I have moved down the assert statement because otherwise `len` will fail on integer arguments, thus the `is int` if statement won't be reached.
I have used [Clock](https://twistedmatrix.com/documents/current/api/twisted.internet.task.Clock.html) to mock the reactor for `CallLaterOnce`, and I have used [MemoryReactor](https://twistedmatrix.com/documents/current/api/twisted.test.proto_helpers.MemoryReactor.html) to mock the reactor for `listen_tcp`.