### PR TITLE
Reverting kafka 1.0.x changes

### DIFF
--- a/frontera/contrib/messagebus/kafka/__init__.py
+++ b/frontera/contrib/messagebus/kafka/__init__.py
@@ -2,7 +2,7 @@
 from collections import namedtuple
 from logging import getLogger
 
-from kafka.common import OffsetRequestPayload, check_error, OffsetFetchRequestPayload, UnknownTopicOrPartitionError
+from kafka.common import OffsetRequest, check_error, OffsetFetchRequest, UnknownTopicOrPartitionError
 
 logger = getLogger("offset-fetcher")
 OffsetsStruct = namedtuple("OffsetsStruct", ["commit", "produced"])
@@ -29,7 +29,7 @@ class OffsetsFetcher(object):
                 the earliest offset will always return you a single element.
         """
         for partition in self._client.get_partition_ids_for_topic(self._topic):
-            reqs = [OffsetRequestPayload(self._topic, partition, -1, 1)]
+            reqs = [OffsetRequest(self._topic, partition, -1, 1)]
 
             (resp,) = self._client.send_offset_request(reqs)
 
@@ -43,7 +43,7 @@ class OffsetsFetcher(object):
         for partition in self._client.get_partition_ids_for_topic(self._topic):
             (resp,) = self._client.send_offset_fetch_request(
                 self._group_id,
-                [OffsetFetchRequestPayload(self._topic, partition)],
+                [OffsetFetchRequest(self._topic, partition)],
                 fail_on_error=False)
             try:
                 check_error(resp)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,5 +5,5 @@ happybase
 w3lib
 msgpack-python
 pyzmq
-kafka-python
+kafka-python<=0.9.5
 pytest>=2.6.4

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,5 +8,5 @@ SQLAlchemy>=1.0.0
 cachetools
 pyzmq
 msgpack-python
-kafka-python
+kafka-python<=0.9.5
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
             'msgpack-python'
         ],
         'kafka': [
-            'kafka-python',
+            'kafka-python<=0.9.5',
             'python-snappy'
         ],
         'distributed': [


### PR DESCRIPTION
The aim is to protect Frontera users from installing newer, yet incompatible kafka-python version.