### PR TITLE
Corporate website friendly canonical solver

### DIFF
--- a/frontera/contrib/canonicalsolvers/__init__.py
+++ b/frontera/contrib/canonicalsolvers/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import basic
+from common import CorporateWebsiteFriendly
 Basic = basic.BasicCanonicalSolver

--- a/frontera/contrib/canonicalsolvers/common.py
+++ b/frontera/contrib/canonicalsolvers/common.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from basic import BasicCanonicalSolver
+from frontera.utils.url import parse_url
+
+
+class CorporateWebsiteFriendly(BasicCanonicalSolver):
+
+    def _set_canonical(self, obj):
+        if 'redirect_urls' in obj.meta:
+            # if home page is requested then leave the target page as canonical
+            urls = obj.meta['redirect_urls']
+            scheme, netloc, path, params, query, fragment = parse_url(urls[0])
+            if not path or path in ['/', 'index.html', 'index.htm', 'default.htm']:
+                return
+
+            # check if redirect is within the same hostname
+            target = parse_url(obj.url)
+            src_hostname, _, _ = netloc.partition(':')
+            trg_hostname, _, _ = target.netloc.partition(':')
+            if src_hostname == trg_hostname:
+                return
+
+            # otherwise default behavior
+            super(CorporateWebsiteFriendly, self)._set_canonical(obj)

--- a/frontera/tests/test_canonical_solver.py
+++ b/frontera/tests/test_canonical_solver.py
@@ -1,15 +1,40 @@
 # -*- coding: utf-8 -*-
-from frontera.contrib.canonicalsolvers import Basic
+from frontera.contrib.canonicalsolvers import Basic, CorporateWebsiteFriendly
 from frontera.core.models import Request, Response
+from frontera.utils.fingerprint import sha1
+
+
+def single_node_chain(url1, url2):
+    r = Request(url=url1)
+    re = Response(url=url2, request=r)
+    re.meta['fingerprint'] = sha1(url2)
+    re.meta['redirect_urls'] = [url1]
+    re.meta['redirect_fingerprints'] = [sha1(url1)]
+    return re
 
 
 def test_basic():
     cs = Basic()
-    r = Request(url="http://www.scrapinghub.com/")
-
-    re = Response(url="http://scrapinghub.com/", request=r)
-    re.meta['fingerprint'] = "6d8afb0c246caa28a2c1bdaaac19c70c24a2d22e"
-    re.meta['redirect_urls'] = ['http://www.scrapinghub.com/']
-    re.meta['redirect_fingerprints'] = ["6cd0a1e069d5a1666a6ec290a4b33f5f325c2e66"]
+    re = single_node_chain("http://www.scrapinghub.com/", "http://scrapinghub.com/")
     cs.page_crawled(re, [])
     assert re.url == "http://www.scrapinghub.com/"
+
+
+def test_corporate_website_friendly():
+    cs = CorporateWebsiteFriendly()
+
+    # check the Basic CS behavior
+    re = single_node_chain("http://www.yandex.ru/company/", "http://google.com/404")
+    cs.page_crawled(re, [])
+    assert re.url == "http://www.yandex.ru/company/"
+
+    # redirect to home page is allowed
+    re = single_node_chain("http://www.yandex.ru", "http://google.com")
+    cs.page_crawled(re, [])
+    assert re.url == "http://google.com"
+
+    # redirect within to internal page is also allowed
+    re = single_node_chain("http://www.yandex.ru", "http://www.yandex.ru/search")
+    cs.page_crawled(re, [])
+    assert re.url == "http://www.yandex.ru/search"
+


### PR DESCRIPTION
So, this differs from BasicCanonicalSolver in a way that if 
- home page is requested (from whatever domain), then leave target page as canonical.
- in case of internal redirects, use target page as canonical.