### PR TITLE
Tests for utils.misc

### DIFF
--- a/frontera/contrib/backends/hbase.py
+++ b/frontera/contrib/backends/hbase.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from calendar import timegm
 from time import time
 from binascii import hexlify, unhexlify
-from zlib import crc32
 from io import BytesIO
 from random import choice
 
@@ -16,7 +15,7 @@ from frontera import DistributedBackend
 from frontera.core.components import Metadata, Queue, States
 from frontera.core.models import Request
 from frontera.contrib.backends.partitioners import Crc32NamePartitioner
-from frontera.utils.misc import chunks
+from frontera.utils.misc import chunks, get_crc32
 import logging
 
 
@@ -113,9 +112,6 @@ class HBaseQueue(Queue):
         :param batch: list of tuples(score, fingerprint, domain, url)
         :return:
         """
-        def get_crc32(name):
-            return crc32(name) if type(name) is str else crc32(name.encode('utf-8', 'ignore'))
-
         def get_interval(score, resolution):
             if score < 0.0 or score > 1.0:
                 raise OverflowError

--- a/frontera/tests/mocks/load_objects.py
+++ b/frontera/tests/mocks/load_objects.py
@@ -1,0 +1,16 @@
+mock_variable = 'test'
+
+
+class MockClass(object):
+
+    val = 10
+
+    def __init__(self, val):
+        self.val = val
+
+
+mock_instance = MockClass(5)
+
+
+def mock_function():
+    return 2

--- a/frontera/tests/test_utils_misc.py
+++ b/frontera/tests/test_utils_misc.py
@@ -1,0 +1,62 @@
+import pytest
+from frontera.utils.misc import load_object, get_crc32, chunks
+
+
+class TestGetCRC32(object):
+
+    def test_bytes(self):
+        assert get_crc32(b'example') == 1861000095
+
+    def test_ascii_unicode(self):
+        assert get_crc32(u'example') == 1861000095
+
+    def test_non_ascii_unicode(self):
+        assert get_crc32(u'example\u5000') == 1259721235
+
+
+class TestChunks(object):
+
+    def test_empty_list(self):
+        assert list(chunks([], 1)) == []
+
+    def test_multiple_length(self):
+        assert list(chunks([1, 2, 3, 4, 5, 6], 2)) == [[1, 2], [3, 4], [5, 6]]
+
+    def test_non_multiple_length(self):
+        assert list(chunks([1, 2, 3, 4, 5, 6, 7, 8], 3)) == [[1, 2, 3], [4, 5, 6], [7, 8]]
+
+
+class TestLoadObject(object):
+
+    def test_load_class(self):
+        obj = load_object('frontera.tests.mocks.load_objects.MockClass')
+        assert obj.val == 10
+
+    def test_load_instance(self):
+        obj = load_object('frontera.tests.mocks.load_objects.mock_instance')
+        assert obj.val == 5
+
+    def test_load_variable(self):
+        obj = load_object('frontera.tests.mocks.load_objects.mock_variable')
+        assert obj == 'test'
+
+    def test_load_function(self):
+        obj = load_object('frontera.tests.mocks.load_objects.mock_function')
+        assert obj() == 2
+
+    def test_value_error(self):
+        with pytest.raises(ValueError) as info:
+            load_object('frontera')
+        assert info.value.message == "Error loading object 'frontera': not a full path"
+
+    def test_import_error(self):
+        with pytest.raises(ImportError) as info:
+            load_object('frontera.non_existent_module.object')
+        assert info.value.message == ("Error loading object 'frontera.non_existent_module.object'"
+                                      ": No module named non_existent_module")
+
+    def test_name_error(self):
+        with pytest.raises(NameError) as info:
+            load_object('frontera.tests.mocks.load_objects.non_existent_object')
+        assert info.value.message == ("Module 'frontera.tests.mocks.load_objects' doesn't define"
+                                      " any object named 'non_existent_object'")


### PR DESCRIPTION
Apart from the tests for utils.misc, I have also removed a copy of the function get_crc32 from hbase, and instead used the one in misc.