### PR TITLE
Tests for frontera scheduler

### DIFF
--- a/frontera/contrib/scrapy/schedulers/frontier.py
+++ b/frontera/contrib/scrapy/schedulers/frontier.py
@@ -71,13 +71,13 @@ class StatsManager(object):
 
 class FronteraScheduler(Scheduler):
 
-    def __init__(self, crawler):
+    def __init__(self, crawler, manager=None):
         self.crawler = crawler
         self.stats_manager = StatsManager(crawler.stats)
         self._pending_requests = deque()
         self.redirect_enabled = crawler.settings.get('REDIRECT_ENABLED')
         settings = ScrapySettingsAdapter(crawler.settings)
-        self.frontier = ScrapyFrontierManager(settings)
+        self.frontier = ScrapyFrontierManager(settings, manager)
         self._delay_on_empty = self.frontier.manager.settings.get('DELAY_ON_EMPTY')
         self._delay_next_call = 0.0
         self.logger = getLogger('frontera.contrib.scrapy.schedulers.FronteraScheduler')

--- a/frontera/tests/mocks/crawler.py
+++ b/frontera/tests/mocks/crawler.py
@@ -1,0 +1,29 @@
+from scrapy.settings import Settings
+from frontera.utils.misc import load_object
+
+
+class FakeCrawler(object):
+
+    class Slot(object):
+
+        def __init__(self, active=0, concurrency=0):
+            self.active = active
+            self.concurrency = concurrency
+
+    def __init__(self, settings=None):
+        self.settings = settings or Settings()
+        self.stats = load_object(self.settings['STATS_CLASS'])(self)
+        dummy_class = type('class', (object,), {})
+        downloader = dummy_class()
+        downloader.slots = {}
+        downloader.domain_concurrency = self.settings.get('CONCURRENT_REQUESTS_PER_DOMAIN')
+        downloader.ip_concurrency = self.settings.get('CONCURRENT_REQUESTS_PER_IP')
+        self.engine = dummy_class()
+        self.engine.downloader = downloader
+        self.engine.downloader.total_concurrency = self.settings.getint('CONCURRENT_REQUESTS')
+
+    def set_slots(self, slotDict):
+        slots = {}
+        for key, slotPair in slotDict.iteritems():
+            slots[key] = self.Slot(slotPair[0], slotPair[1])
+        self.engine.downloader.slots = slots

--- a/frontera/tests/mocks/frontier_manager.py
+++ b/frontera/tests/mocks/frontier_manager.py
@@ -1,0 +1,58 @@
+from frontera.settings import Settings
+
+
+class FakeFrontierManager(object):
+
+    def __init__(self, settings):
+        self.settings = settings
+        self.auto_start = settings.get('AUTO_START')
+        self.iteration = 0
+        self.finished = False
+        self._started = True
+        self._stopped = False
+        self.seeds = []
+        self.requests = []
+        self.links = []
+        self.responses = []
+        self.errors = []
+        self.get_next_requests_kwargs = []
+
+    @classmethod
+    def from_settings(cls, settings=None):
+        settings = Settings.object_from(settings)
+        return FakeFrontierManager(settings)
+
+    def start(self):
+        self._started = True
+
+    def stop(self):
+        self._stopped = True
+
+    def add_seeds(self, seeds):
+        for seed in seeds:
+            self.seeds.append(seed)
+
+    def put_requests(self, requests):
+        for request in requests:
+            self.requests.append(request)
+
+    def get_next_requests(self, max_next_requests=0, **kwargs):
+        self.get_next_requests_kwargs.append(kwargs)
+        max_next_requests = max_next_requests or self.settings.get('MAX_NEXT_REQUESTS')
+        lst = []
+        for i in range(max_next_requests):
+            if self.requests:
+                lst.append(self.requests.pop())
+        self.iteration += 1
+        return lst
+
+    def page_crawled(self, response, links=None):
+        if links:
+            for link in links:
+                self.links.append(link)
+        self.responses.append(response)
+
+    def request_error(self, request, error):
+        self.errors.append((request, error))
+
+

--- a/frontera/tests/test_frontera_scheduler.py
+++ b/frontera/tests/test_frontera_scheduler.py
@@ -1,0 +1,150 @@
+from frontera.contrib.scrapy.schedulers.frontier import FronteraScheduler
+from frontera.tests.mocks.frontier_manager import FakeFrontierManager
+from frontera.tests.mocks.crawler import FakeCrawler
+from frontera.core.models import Request as FRequest
+from frontera.core.models import Response as FResponse
+from scrapy.http import Request, Response
+from scrapy.spiders import Spider
+from scrapy.settings import Settings
+
+
+# test requests
+r1 = Request('http://www.example.com')
+r2 = Request('https://www.example.com/some/page')
+r3 = Request('http://example1.com')
+
+
+# test requests with redirects
+rr1 = Request('http://www.example.com', meta={'redirect_times': 1})
+rr2 = Request('https://www.example.com/some/page', meta={'redirect_times': 4})
+rr3 = Request('http://example1.com', meta={'redirect_times': 0})
+
+
+# test frontier requests
+fr1 = FRequest('http://www.example.com')
+fr2 = Request('https://www.example.com/some/page')
+fr3 = Request('http://example1.com')
+
+
+class TestFronteraScheduler(object):
+
+    def test_enqueue_requests(self):
+        crawler = FakeCrawler()
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        assert fs.enqueue_request(r1) is True
+        assert fs.enqueue_request(r2) is True
+        assert fs.enqueue_request(r3) is True
+        assert set(seed.url for seed in fs.frontier.manager.seeds) == set([r1.url, r2.url, r3.url])
+        assert all([isinstance(seed, FRequest) for seed in fs.frontier.manager.seeds])
+        assert fs.stats_manager.stats.get_value('frontera/seeds_count') == 3
+
+    def test_redirect_disabled_enqueue_requests(self):
+        settings = Settings()
+        settings['REDIRECT_ENABLED'] = False
+        crawler = FakeCrawler(settings)
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        assert fs.enqueue_request(rr1) is False
+        assert fs.enqueue_request(rr2) is False
+        assert fs.enqueue_request(rr3) is True
+        assert isinstance(fs.frontier.manager.seeds[0], FRequest)
+        assert len(fs.frontier.manager.seeds) == 1
+        assert fs.frontier.manager.seeds[0].url == rr3.url
+        assert fs.stats_manager.stats.get_value('frontera/seeds_count') == 1
+
+    def test_redirect_enabled_enqueue_requests(self):
+        settings = Settings()
+        settings['REDIRECT_ENABLED'] = True
+        crawler = FakeCrawler(settings)
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        assert fs.enqueue_request(rr1) is True
+        assert fs.enqueue_request(rr2) is True
+        assert fs.enqueue_request(rr3) is True
+        assert len(fs.frontier.manager.seeds) == 1
+        assert isinstance(fs.frontier.manager.seeds[0], FRequest)
+        assert fs.frontier.manager.seeds[0].url == rr3.url
+        assert set([request.url for request in fs._pending_requests]) == set([rr1.url, rr2.url])
+        assert all([isinstance(request, Request) for request in fs._pending_requests])
+        assert fs.stats_manager.stats.get_value('frontera/seeds_count') == 1
+        assert fs.stats_manager.stats.get_value('frontera/redirected_requests_count') == 2
+
+    def test_next_request(self):
+        crawler = FakeCrawler()
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        fs.frontier.manager.put_requests([fr1, fr2, fr3])
+        requests = [fs.next_request() for _ in range(3)]
+        assert set([request.url for request in requests]) == set([fr1.url, fr2.url, fr3.url])
+        assert all([isinstance(request, Request) for request in requests])
+        assert fs.stats_manager.stats.get_value('frontera/returned_requests_count') == 3
+
+    def test_next_request_manager_finished(self):
+        crawler = FakeCrawler()
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        fs.frontier.manager.put_requests([fr1])
+        fs.frontier.manager.finished = True
+        assert fs.next_request() is None
+        assert fs.stats_manager.stats.get_value('frontera/returned_requests_count') is None
+
+    def test_next_request_overused_keys_info(self):
+        settings = Settings()
+        settings['CONCURRENT_REQUESTS_PER_DOMAIN'] = 0
+        settings['CONCURRENT_REQUESTS_PER_IP'] = 1
+        crawler = FakeCrawler(settings)
+        # the keys in the slot_dict are ip's, the first value in the pair is the
+        # slot.active list(only it's length is needed) and the second value is slot.concurrency.
+        slot_dict = {'1.2.3': ([0]*3, 1), '2.1.3': ([0]*30, 2), '3.2.2': ([0]*5, 1), '4.1.3': ([0]*110, 20)}
+        crawler.set_slots(slot_dict)
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        fs.frontier.manager.put_requests([fr1])
+        request = fs.next_request()
+        assert request.url == fr1.url
+        assert isinstance(request, Request)
+        assert fs.frontier.manager.get_next_requests_kwargs[0]['key_type'] == 'ip'
+        assert set(fs.frontier.manager.get_next_requests_kwargs[0]['overused_keys']) == set(['2.1.3', '4.1.3'])
+        assert fs.stats_manager.stats.get_value('frontera/returned_requests_count') == 1
+
+    def test_process_spider_output(self):
+        i1 = {'name': 'item', 'item': 'i1'}
+        i2 = {'name': 'item', 'item': 'i2'}
+        result = [r1, r2, r3, i1, i2]
+        resp = Response(fr1.url, request=Request(fr1.url, meta={'frontier_request': fr1}))
+        crawler = FakeCrawler()
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        assert sorted(list(fs.process_spider_output(resp, result, Spider))) == sorted([i1, i2])
+        assert isinstance(fs.frontier.manager.responses[0], FResponse)
+        assert fs.frontier.manager.responses[0].url == resp.url
+        assert set([request.url for request in fs.frontier.manager.links]) == set([r1.url, r2.url, r3.url])
+        assert all([isinstance(request, FRequest) for request in fs.frontier.manager.links])
+        assert fs.stats_manager.stats.get_value('frontera/crawled_pages_count') == 1
+        assert fs.stats_manager.stats.get_value('frontera/crawled_pages_count/200') == 1
+        assert fs.stats_manager.stats.get_value('frontera/links_extracted_count') == 3
+
+    def test_process_exception(self):
+        exception = type('exception', (object,), {})
+        crawler = FakeCrawler()
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        fs.process_exception(r1, exception(), Spider)
+        error = fs.frontier.manager.errors.pop()
+        assert error[0].url == r1.url
+        assert error[1] == 'exception'
+        assert fs.stats_manager.stats.get_value('frontera/request_errors_count') == 1
+        assert fs.stats_manager.stats.get_value('frontera/request_errors_count/exception') == 1
+
+    def test_close(self):
+        crawler = FakeCrawler()
+        fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
+        fs.open(Spider)
+        fs.frontier.manager.put_requests([fr1, fr2, fr3])
+        fs.next_request()
+        fs.frontier.manager.iteration = 5
+        fs.close('reason')
+        assert fs.frontier.manager._stopped is True
+        assert fs.stats_manager.stats.get_value('frontera/pending_requests_count') == 2
+        assert fs.stats_manager.stats.get_value('frontera/iterations') == 5

--- a/frontera/tests/test_frontera_scheduler.py
+++ b/frontera/tests/test_frontera_scheduler.py
@@ -92,7 +92,7 @@ class TestFronteraScheduler(object):
     def test_next_request_overused_keys_info(self):
         settings = Settings()
         settings['CONCURRENT_REQUESTS_PER_DOMAIN'] = 0
-        settings['CONCURRENT_REQUESTS_PER_IP'] = 1
+        settings['CONCURRENT_REQUESTS_PER_IP'] = 5
         crawler = FakeCrawler(settings)
         # the keys in the slot_dict are ip's, the first value in the pair is the
         # slot.active list(only it's length is needed) and the second value is slot.concurrency.

--- a/frontera/utils/managers.py
+++ b/frontera/utils/managers.py
@@ -4,8 +4,9 @@ from converters import BaseRequestConverter, BaseResponseConverter
 
 class FrontierManagerWrapper(object):
 
-    def __init__(self, settings):
-        self.manager = FrontierManager.from_settings(settings)
+    def __init__(self, settings, manager=None):
+        manager = manager or FrontierManager
+        self.manager = manager.from_settings(settings)
 
     def start(self):
         if not hasattr(self, 'request_converter'):


### PR DESCRIPTION
Both the crawler and FrontierManager are faked. The fake crawler is needed to calculate the overused keys calculation, so it only contains some settings, and a function to setup fake slot info. The fake FrontierManager records all the requests, responses, errors, and arguments, in lists. The actual test just call the functions, and verify the types and content of the values stored in the FrontierManager object.