### PR TITLE
Use SQLAlchemyBackend for example general spider by default

### DIFF
--- a/examples/general-spider/frontier/workersettings.py
+++ b/examples/general-spider/frontier/workersettings.py
@@ -9,8 +9,8 @@ SPIDER_LOG_PARTITIONS = 1
 # Url storage
 #--------------------------------------------------------
 
-#BACKEND = 'frontera.contrib.backends.sqlalchemy.SQLAlchemyBackend'
-BACKEND = 'frontera.contrib.backends.sqlalchemy.Distributed'
+BACKEND = 'frontera.contrib.backends.sqlalchemy.SQLAlchemyBackend'
+#BACKEND = 'frontera.contrib.backends.sqlalchemy.Distributed'
 
 
 SQLALCHEMYBACKEND_ENGINE = 'sqlite:///url_storage_dist.sqlite'


### PR DESCRIPTION
To make quick-start-distributed tutorial works out of the box. Fixes #155 