### PR TITLE
Check if table already exists before creating it

### DIFF
--- a/frontera/contrib/backends/sqlalchemy/__init__.py
+++ b/frontera/contrib/backends/sqlalchemy/__init__.py
@@ -132,7 +132,7 @@ class Distributed(DistributedBackend):
         if drop_all_tables:
             if model.__table__.name in inspector.get_table_names():
                 model.__table__.drop(bind=b.engine)
-        model.__table__.create(bind=b.engine)
+        model.__table__.create(bind=b.engine, checkfirst=True)
 
         if clear_content:
             session = b.session_cls()
@@ -158,8 +158,8 @@ class Distributed(DistributedBackend):
                 metadata_m.__table__.drop(bind=b.engine)
             if queue_m.__table__.name in existing:
                 queue_m.__table__.drop(bind=b.engine)
-        metadata_m.__table__.create(bind=b.engine)
-        queue_m.__table__.create(bind=b.engine)
+        metadata_m.__table__.create(bind=b.engine, checkfirst=True)
+        queue_m.__table__.create(bind=b.engine, checkfirst=True)
 
         if clear_content:
             session = b.session_cls()


### PR DESCRIPTION
If we have SQLALCHEMYBACKEND_DROP_ALL_TABLES = False, then without this fix we will fail to start db and strategy workers with an existing database, because the tables are already there, but we try to create them.

Potentially, creating the table without checking for existance could cause troubles even with SQLALCHEMYBACKEND_DROP_ALL_TABLES = True, when several workers would try to create required tables concurrently, but I never tried to reproduce this.