### PR TITLE
Fix SQL integer type for crc32 field

### DIFF
--- a/frontera/contrib/backends/partitioners.py
+++ b/frontera/contrib/backends/partitioners.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from zlib import crc32
 from struct import unpack
 from binascii import unhexlify
 

--- a/frontera/utils/misc.py
+++ b/frontera/utils/misc.py
@@ -32,7 +32,19 @@ def load_object(path):
 
 
 def get_crc32(name):
-    return crc32(to_bytes(name, 'utf-8', 'ignore'))
+    """ signed crc32 of bytes or unicode.
+    In python 3, return the same number as in python 2, converting to
+    [-2**31, 2**31-1] range. This is done to maintain backwards compatibility
+    with python 2, since checksums are stored in the database, so this allows
+    to keep the same database schema.
+    """
+    return to_signed32(crc32(to_bytes(name, 'utf-8', 'ignore')))
+
+
+def to_signed32(x):
+    """ If x is an usigned 32-bit int, convert it to a signed 32-bit.
+    """
+    return x - 0x100000000 if x > 0x7fffffff else x
 
 
 def chunks(l, n):

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
+import hashlib
 import pytest
-from frontera.utils.misc import load_object, get_crc32, chunks
+from frontera.utils.misc import load_object, get_crc32, chunks, to_signed32
 import six
 
 
@@ -17,6 +18,17 @@ class TestGetCRC32(object):
 
     def test_non_ascii_bytes(self):
         assert get_crc32(u'example\u5000'.encode('utf8')) == 1259721235
+
+    def test_negative_crc32(self):
+        assert get_crc32(b'1') == -2082672713
+
+    def test_crc32_range(self):
+        left, right = -2**31, 2**31 - 1
+        for x in range(10000):
+            assert left <= get_crc32(hashlib.md5(str(x)).hexdigest()) <= right
+        for x in [left, left + 1, right - 1, right, right + 1,
+                  2**32 - 2, 2**32 - 1]:
+            assert left <= to_signed32(x) <= right
 
 
 class TestChunks(object):

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -25,7 +25,8 @@ class TestGetCRC32(object):
     def test_crc32_range(self):
         left, right = -2**31, 2**31 - 1
         for x in range(10000):
-            assert left <= get_crc32(hashlib.md5(str(x)).hexdigest()) <= right
+            bytestr = hashlib.md5(str(x).encode('ascii')).hexdigest()
+            assert left <= get_crc32(bytestr) <= right
         for x in [left, left + 1, right - 1, right, right + 1,
                   2**32 - 2, 2**32 - 1]:
             assert left <= to_signed32(x) <= right


### PR DESCRIPTION
CRC32 is an unsigned 4-byte int, so it does not fit in a signed 4-byte int (``Integer``). There is no unsigned int type in the SQL standard, so I changed it to ``BigInteger `` instead. Without this change, both MySQL and Postgres complain that ``host_crc32`` field value is out of bounds. 
Another option (to save space) would be to conver CRC32 into a signed 4-bit int, but this will complicate things, not sure it's worth it.