### PR TITLE
Allow passing py.test args with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements/tests.txt
 commands =
-    py.test --cov-report=term --cov=frontera -s -v tests
+    py.test --cov-report=term --cov=frontera -s -v {posargs:tests}
 
 [testenv:flake8]
 changedir = {toxinidir}


### PR DESCRIPTION
This allows to run only specified tests under tox:

    tox -e py27,py35 -- tests/test_utils_misc.py::TestGetCRC32

When nothing is specified, "tests" is passed as default value, as before. I saw that in scrapy: https://github.com/scrapy/scrapy/blob/1075587dbd15e5ccb9a83c4ca14086c1e135fe12/tox.ini#L22. During development, this simplifies testing code that must work in different python versions, so you can check new tests or fixes with one command.