### PR TITLE
Alternative fix to #211 by forcing scrapy meta encoding to unicode at messagebus

### DIFF
--- a/frontera/contrib/backends/remote/codecs/msgpack.py
+++ b/frontera/contrib/backends/remote/codecs/msgpack.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from msgpack import packb, unpackb
 
 from frontera.core.codec import BaseDecoder, BaseEncoder
+from frontera.utils.misc import dict_to_unicode
 import six
 from w3lib.util import to_native_str
 
@@ -80,11 +81,13 @@ class Decoder(BaseDecoder):
                                                                 meta=obj[2]))
 
     def _request_from_object(self, obj):
+        meta = {k: v if 'scrapy' not in k.decode('utf-8') else dict_to_unicode(v)
+                for k, v in six.iteritems(obj[4])}
         return self._request_model(url=to_native_str(obj[0]),
                                    method=obj[1],
                                    headers=obj[2],
                                    cookies=obj[3],
-                                   meta=obj[4])
+                                   meta=meta)
 
     def decode(self, buffer):
         obj = unpackb(buffer)

--- a/tests/contrib/backends/remote/test_messagebus.py
+++ b/tests/contrib/backends/remote/test_messagebus.py
@@ -1,0 +1,20 @@
+from frontera.contrib.backends.remote.codecs.msgpack import Decoder
+from frontera.contrib.backends.remote.codecs.msgpack import Encoder
+from frontera.core.models import Request
+
+
+class DumbResponse:
+    pass
+
+
+class TestMsgpackMessageBus(object):
+
+    def test_request_scrapy_meta_is_preserved(self):
+        meta = {b'frontera_key': b'frontera_value',
+                b'scrapy_meta': {'rule': 0, 'link': 'some_link'}}
+        r = Request('http://example.com',
+                    meta=meta)
+        encoder = Encoder(Request)
+        decoder = Decoder(Request, DumbResponse)
+        response_meta = decoder.decode_request(encoder.encode_request(r)).meta
+        assert response_meta == meta


### PR DESCRIPTION
Given the discussion in #211 and my original attempt to fix it in #212, I thought I'd make another PR so we could make a decision between the two and simply abandon the other. Thank you @voith for weighing in, I pretty much used your repl code verbatim for the test.

IMO, this isn't ideal as we are making an assumption here. The best solution would be to preserve `meta` encoding by generating and storing the `meta`'s _meta_ in the outgoing message, which should provide enough information for us to decode it properly at he other end, but that would be more work, do wanted everyone's opinion first. I'm happy to look into that if everyone agrees that is way forward.
