### PR TITLE
remove obsolete line from travis.yml to fix current build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ install:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y --force-yes -o Dpkg::Options::="--force-confold" install docker-engine mysql-server
   - sudo rm -f /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose


### PR DESCRIPTION
frontera builds are currently failing. eg https://travis-ci.org/scrapinghub/frontera/builds/182865294
This PR fixes the build error by removing an obsolete line in travis.yml