### PR TITLE
Don’t change scrapy.settings.default_settings.

### DIFF
--- a/docs/source/topics/cluster-setup.rst
+++ b/docs/source/topics/cluster-setup.rst
@@ -106,18 +106,17 @@ The logging can be configured according to https://docs.python.org/2/library/log
 6. Configure Scrapy settings module. It's located in Scrapy project folder and referenced in scrapy.cfg. Let's add
 there::
 
-    from scrapy.settings.default_settings import SPIDER_MIDDLEWARES, DOWNLOADER_MIDDLEWARES
-
     FRONTERA_SETTINGS = ''  # module path to your Frontera spider config module
 
     SCHEDULER = 'frontera.contrib.scrapy.schedulers.frontier.FronteraScheduler'
-    SPIDER_MIDDLEWARES.update({
+
+    SPIDER_MIDDLEWARES = {
         'frontera.contrib.scrapy.middlewares.schedulers.SchedulerSpiderMiddleware': 999,
         'frontera.contrib.scrapy.middlewares.seeds.file.FileSeedLoader': 1,
-    })
-    DOWNLOADER_MIDDLEWARES.update({
+    }
+    DOWNLOADER_MIDDLEWARES = {
         'frontera.contrib.scrapy.middlewares.schedulers.SchedulerDownloaderMiddleware': 999,
-    })
+    }
 
 
 Starting the cluster

--- a/examples/cluster/bc/settings.py
+++ b/examples/cluster/bc/settings.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
-from scrapy.settings.default_settings import SPIDER_MIDDLEWARES, DOWNLOADER_MIDDLEWARES
-
 FRONTERA_SETTINGS = 'bc.config.spider'
 
 SCHEDULER = 'frontera.contrib.scrapy.schedulers.frontier.FronteraScheduler'
-SPIDER_MIDDLEWARES.update({
+SPIDER_MIDDLEWARES = {
     'frontera.contrib.scrapy.middlewares.schedulers.SchedulerSpiderMiddleware': 999,
     'frontera.contrib.scrapy.middlewares.seeds.file.FileSeedLoader': 1,
-})
-DOWNLOADER_MIDDLEWARES.update({
+}
+DOWNLOADER_MIDDLEWARES = {
     'frontera.contrib.scrapy.middlewares.schedulers.SchedulerDownloaderMiddleware': 999,
-})
+}
 
 BOT_NAME = 'bc'
 

--- a/examples/general-spider/general/settings.py
+++ b/examples/general-spider/general/settings.py
@@ -1,14 +1,4 @@
 # -*- coding: utf-8 -*-
-
-# Scrapy settings for topic project
-#
-# For simplicity, this file contains only the most important settings by
-# default. All the other settings are documented here:
-#
-#     http://doc.scrapy.org/en/latest/topics/settings.html
-#
-from scrapy.settings.default_settings import SPIDER_MIDDLEWARES, DOWNLOADER_MIDDLEWARES
-
 BOT_NAME = 'general'
 
 SPIDER_MODULES = ['general.spiders']
@@ -17,22 +7,20 @@ NEWSPIDER_MODULE = 'general.spiders'
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 #USER_AGENT = 'topic (+http://www.yourdomain.com)'
 
-SPIDER_MIDDLEWARES.update({
+SPIDER_MIDDLEWARES = {
+    'frontera.contrib.scrapy.middlewares.seeds.file.FileSeedLoader': 1,
     'frontera.contrib.scrapy.middlewares.schedulers.SchedulerSpiderMiddleware': 1000,
     'scrapy.spidermiddleware.depth.DepthMiddleware': None,
     'scrapy.spidermiddleware.offsite.OffsiteMiddleware': None,
     'scrapy.spidermiddleware.referer.RefererMiddleware': None,
     'scrapy.spidermiddleware.urllength.UrlLengthMiddleware': None
-})
+}
 
-DOWNLOADER_MIDDLEWARES.update({
+DOWNLOADER_MIDDLEWARES = {
     'frontera.contrib.scrapy.middlewares.schedulers.SchedulerDownloaderMiddleware': 1000,
-})
+}
 
 SCHEDULER = 'frontera.contrib.scrapy.schedulers.frontier.FronteraScheduler'
-SPIDER_MIDDLEWARES.update({
-    'frontera.contrib.scrapy.middlewares.seeds.file.FileSeedLoader': 1,
-})
 
 
 HTTPCACHE_ENABLED = False
@@ -58,4 +46,3 @@ LOG_LEVEL = 'INFO'
 
 REACTOR_THREADPOOL_MAXSIZE = 32
 DNS_TIMEOUT = 180
-

--- a/examples/scrapy_recording/scrapy_recording/settings.py
+++ b/examples/scrapy_recording/scrapy_recording/settings.py
@@ -17,22 +17,18 @@ CONCURRENT_REQUESTS_PER_DOMAIN = 2
 
 LOGSTATS_INTERVAL = 10
 
-SPIDER_MIDDLEWARES = {}
-DOWNLOADER_MIDDLEWARES = {}
-
 #--------------------------------------------------------------------------
 # Recorder Settings
 #--------------------------------------------------------------------------
-SPIDER_MIDDLEWARES.update(
-    {'frontera.contrib.scrapy.middlewares.schedulers.SchedulerSpiderMiddleware': 999},
-)
-DOWNLOADER_MIDDLEWARES.update(
-    {'frontera.contrib.scrapy.middlewares.schedulers.SchedulerDownloaderMiddleware': 999}
-)
+SPIDER_MIDDLEWARES = {
+    'frontera.contrib.scrapy.middlewares.schedulers.SchedulerSpiderMiddleware': 999
+}
+DOWNLOADER_MIDDLEWARES = {
+    'frontera.contrib.scrapy.middlewares.schedulers.SchedulerDownloaderMiddleware': 999
+}
 SCHEDULER = 'frontera.contrib.scrapy.schedulers.recording.RecorderScheduler'
 
 RECORDER_ENABLED = True
 RECORDER_STORAGE_ENGINE = 'sqlite:///scrapy_recording/recordings/record.db'
 RECORDER_STORAGE_DROP_ALL_TABLES = True
 RECORDER_STORAGE_CLEAR_CONTENT = True
-

--- a/tests/scrapy_spider/settings.py
+++ b/tests/scrapy_spider/settings.py
@@ -17,18 +17,15 @@ CONCURRENT_REQUESTS_PER_DOMAIN = 2
 
 LOGSTATS_INTERVAL = 10
 
-SPIDER_MIDDLEWARES = {}
-DOWNLOADER_MIDDLEWARES = {}
-
 #--------------------------------------------------------------------------
 # Frontier Settings
 #--------------------------------------------------------------------------
-SPIDER_MIDDLEWARES.update(
-    {'frontera.contrib.scrapy.middlewares.schedulers.SchedulerSpiderMiddleware': 999},
-)
-DOWNLOADER_MIDDLEWARES.update(
-    {'frontera.contrib.scrapy.middlewares.schedulers.SchedulerDownloaderMiddleware': 999}
-)
+SPIDER_MIDDLEWARES = {
+    'frontera.contrib.scrapy.middlewares.schedulers.SchedulerSpiderMiddleware': 999
+}
+DOWNLOADER_MIDDLEWARES = {
+    'frontera.contrib.scrapy.middlewares.schedulers.SchedulerDownloaderMiddleware': 999
+}
 SCHEDULER = 'frontera.contrib.scrapy.schedulers.frontier.FronteraScheduler'
 FRONTERA_SETTINGS = 'tests.scrapy_spider.frontera.settings'
 


### PR DESCRIPTION
I haven't changed some of the examples in the docs because technically they are still correct: if you already have e.g. DOWNLOADER__MIDDLEWARES enabled you can use `.update({...})` to add frontera middlewares. All `scrapy.settings.default_settings` mentions are removed. It should fix #242.