### PR TITLE
don’t run Travis tests multiple times for pull requests from branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
 python: 2.7
+branches:
+  only:
+    - master
+    - /^\d\.\d+$/
+    - /^\d\.\d+\.\d+(rc\d+|dev\d+)?$/
 
 services:
   - docker


### PR DESCRIPTION
For example, in https://github.com/scrapinghub/frontera/pull/244 Travis tests were executed twice. The fix is copy-pasted from scrapy config.