### PR TITLE
Fixed json codec when send_body=False

### DIFF
--- a/frontera/contrib/backends/remote/codecs/json.py
+++ b/frontera/contrib/backends/remote/codecs/json.py
@@ -106,7 +106,7 @@ class Decoder(json.JSONDecoder, BaseDecoder):
                                       meta=obj[b'meta'])
         return self._response_model(url=url,
                                     status_code=obj[b'status_code'],
-                                    body=b64decode(obj[b'body']),
+                                    body=b64decode(obj[b'body']) if obj[b'body'] is not None else None,
                                     request=request)
 
     def _request_from_object(self, obj):


### PR DESCRIPTION
I was getting the following Error while using json codec in distributed mode:
```
ERROR:strategy-worker:a2b_base64() argument 1 must be string or buffer, not None
Traceback (most recent call last):
  File "/Users/voith/Projects/Open-Source/frontera-google/venv/src/fix-msgpack-codec/frontera/worker/strategy.py", line 128, in collect_batch
    msg = self._decoder.decode(m)
  File "/Users/voith/Projects/Open-Source/frontera-google/venv/src/fix-msgpack-codec/frontera/contrib/backends/remote/codecs/json.py", line 176, in decode
    response = self._response_from_object(message['r'])
  File "/Users/voith/Projects/Open-Source/frontera-google/venv/src/fix-msgpack-codec/frontera/contrib/backends/remote/codecs/json.py", line 159, in _response_from_object
    body=b64decode(obj['body']),
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/base64.py", line 75, in b64decode
    return binascii.a2b_base64(s)
TypeError: a2b_base64() argument 1 must be string or buffer, not None
```