### PR TITLE
Fixed scheduler process_spider_output() to yield requests

### DIFF
--- a/frontera/contrib/scrapy/schedulers/frontier.py
+++ b/frontera/contrib/scrapy/schedulers/frontier.py
@@ -110,8 +110,7 @@ class FronteraScheduler(Scheduler):
         for element in result:
             if isinstance(element, Request):
                 links.append(element)
-            else:
-                yield element
+            yield element
         frontier_request = response.meta[b'frontier_request']
         self.frontier.page_crawled(response)  # removed frontier part from .meta
         # putting it back, to persist .meta from original request

--- a/tests/test_frontera_scheduler.py
+++ b/tests/test_frontera_scheduler.py
@@ -113,12 +113,18 @@ class TestFronteraScheduler(object):
     def test_process_spider_output(self):
         i1 = {'name': 'item', 'item': 'i1'}
         i2 = {'name': 'item', 'item': 'i2'}
+        no_requests = 3
         result = [r1, r2, r3, i1, i2]
         resp = Response(fr1.url, request=Request(fr1.url, meta={b'frontier_request': fr1}))
         crawler = FakeCrawler()
         fs = FronteraScheduler(crawler, manager=FakeFrontierManager)
         fs.open(Spider)
-        assert sorted(list(fs.process_spider_output(resp, result, Spider)), key=lambda i: sorted(i['item'])) == \
+        out = list(fs.process_spider_output(resp, result, Spider))
+        assert len(out) == len(result)
+        out_request = out[:no_requests]
+        assert set(r.url for r in out_request) == set(r.url for r in result[:no_requests])
+        out_items = out[no_requests:]
+        assert sorted(out_items, key=lambda i: sorted(i['item'])) == \
             sorted([i1, i2], key=lambda i: sorted(i['item']))
         assert isinstance(fs.frontier.manager.responses[0], FResponse)
         assert fs.frontier.manager.responses[0].url == resp.url


### PR DESCRIPTION
fixes #253 
Here's a screenshot using the same code discussed [here](https://github.com/scrapinghub/frontera/issues/253#issue-207038554).
<img width="1666" alt="screen shot 2017-02-12 at 3 13 48 pm" src="https://cloud.githubusercontent.com/assets/8171193/22861094/4a8a68c6-f136-11e6-9978-921a1f78b89f.png">

Nothing seems to break when testing this change manually. The only [test](https://github.com/scrapinghub/frontera/blob/master/tests/test_frontera_scheduler.py#L121-L122) that was failing was wrong IMO because it passed a list of requests and items and was only expecting items in return. I have modified that test to make it compatible with this patch.

I've the split this PR into three commits:
- The first commit adds a test to reproduce the bug.
- The second commit fixes the bug
- The third commit fixes the broken test discussed above

<h3>A note about the tests added:</h3> 
The tests might be a little difficult to understand on the first sight. I would recommend to read the following code in order understand the tests:

- https://github.com/scrapy/scrapy/blob/master/scrapy/core/spidermw.py#L34-L73: This is to understand how scrapy processes the different methods of the spider middleware.
- https://github.com/scrapy/scrapy/blob/master/scrapy/core/scraper.py#L135-L147: This is to understand how the scrapy core executes the spider middleware methods and passes the control to the spider callbacks.

I have simulated the above discussed code in order to write the test.  
