### PR TITLE
avoid some useless warning or error

### DIFF
--- a/frontera/contrib/backends/remote/codecs/msgpack.py
+++ b/frontera/contrib/backends/remote/codecs/msgpack.py
@@ -30,7 +30,8 @@ def _prepare_request_message(request):
         elif hasattr(obj, '__dict__'):
             return serialize(obj.__dict__)
         else:
-            logger.warning('unable to serialize object: {}'.format(obj))
+            if obj:
+                logger.warning('unable to serialize object: {}'.format(obj))
             return None
     return [request.url, request.method, request.headers, request.cookies, serialize(request.meta)]
 

--- a/frontera/contrib/messagebus/zeromq/__init__.py
+++ b/frontera/contrib/messagebus/zeromq/__init__.py
@@ -98,7 +98,7 @@ class Producer(object):
         pass
 
     def get_offset(self, partition_id):
-        return self.counters.get(partition_id,0)
+        return self.counters.get(partition_id, 0)
 
 
 class SpiderLogProducer(Producer):

--- a/frontera/contrib/messagebus/zeromq/__init__.py
+++ b/frontera/contrib/messagebus/zeromq/__init__.py
@@ -98,7 +98,7 @@ class Producer(object):
         pass
 
     def get_offset(self, partition_id):
-        return self.counters[partition_id]
+        return self.counters.get(partition_id,0)
 
 
 class SpiderLogProducer(Producer):


### PR DESCRIPTION
When I run **general-spider** in the examples, I get some errors and warnings. After reading the source code, I find that they did not affect the result,  but they are really distrubing and misleading, especially to newcomer like me. So I make this pull request.

The warning:
```
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
2017-02-16 11:48:05 [frontera.contrib.backends.remote.codecs.msgpack] WARNING: unable to serialize object: None
......
```

The error:
```
 2017-02-16 10:33:54,650 /Library/Python/2.7/site-packages/frontera/worker/db.py error[line:48] ERROR    db-worker       0
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/twisted/internet/defer.py", line 587, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/Library/Python/2.7/site-packages/frontera/utils/async.py", line 41, in __call__
    return self._func(*self._a, **self._kw)
  File "/Library/Python/2.7/site-packages/frontera/worker/db.py", line 172, in consume_incoming
    producer_offset = self.spider_feed_producer.get_offset(partition_id)
  File "/Library/Python/2.7/site-packages/frontera/contrib/messagebus/zeromq/__init__.py", line 103, in get_offset
    return self.counters[partition_id]
KeyError: 0
Unhandled error in Deferred:


Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/twisted/internet/base.py", line 1204, in mainLoop
    self.runUntilCurrent()
  File "/Library/Python/2.7/site-packages/twisted/internet/base.py", line 825, in runUntilCurrent
    call.func(*call.args, **call.kw)
  File "/Library/Python/2.7/site-packages/twisted/internet/defer.py", line 393, in callback
    self._startRunCallbacks(result)
  File "/Library/Python/2.7/site-packages/twisted/internet/defer.py", line 501, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/Library/Python/2.7/site-packages/twisted/internet/defer.py", line 587, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/Library/Python/2.7/site-packages/frontera/utils/async.py", line 41, in __call__
    return self._func(*self._a, **self._kw)
  File "/Library/Python/2.7/site-packages/frontera/worker/db.py", line 172, in consume_incoming
    producer_offset = self.spider_feed_producer.get_offset(partition_id)
  File "/Library/Python/2.7/site-packages/frontera/contrib/messagebus/zeromq/__init__.py", line 103, in get_offset
    return self.counters[partition_id]
exceptions.KeyError: 0
```