### PR TITLE
Feature Redis Backend for Frontera

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
   - docker
   - mysql
   - postgresql
+  - redis-server
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
         - docker
         - mysql
         - postgresql
+        - redis-server
 
 install:
   - pip install -U tox wheel codecov

--- a/docs/source/topics/frontier-backends.rst
+++ b/docs/source/topics/frontier-backends.rst
@@ -289,6 +289,19 @@ setting.
     Queue exploration
     shuffling with MR jobs
 
+Redis backend
+^^^^^^^^^^^^^
+
+.. autoclass:: frontera.contrib.backends.redis_backend.RedisBackend
+
+This is similar to the HBase backend. It is suitable for large scale crawlers that still has a limited scope. It is
+recommended to ensure Redis is allowed to use enough memory to store all metadata the crawler needs. In case of Redis
+running out of memory, the crawler will log this and continue. When the crawler is unable to write metadata to the
+database; that metadata is lost.
+
+In case of connection errors; the crawler will attempt to reconnect three times. If the third attempt at connecting
+to Redis fails, the worker will skip that Redis operation and continue operating.
+
 .. _FIFO: http://en.wikipedia.org/wiki/FIFO
 .. _LIFO: http://en.wikipedia.org/wiki/LIFO_(computing)
 .. _DFS: http://en.wikipedia.org/wiki/Depth-first_search
@@ -298,3 +311,4 @@ setting.
 .. _SQLAlchemy: http://www.sqlalchemy.org/
 .. _any databases supported by SQLAlchemy: http://docs.sqlalchemy.org/en/latest/dialects/index.html
 .. _declarative sqlalchemy models: http://docs.sqlalchemy.org/en/latest/orm/extensions/declarative/index.html
+

--- a/docs/source/topics/frontier-backends.rst
+++ b/docs/source/topics/frontier-backends.rst
@@ -295,9 +295,9 @@ Redis backend
 .. autoclass:: frontera.contrib.backends.redis_backend.RedisBackend
 
 This is similar to the HBase backend. It is suitable for large scale crawlers that still has a limited scope. It is
-recommended to ensure Redis is allowed to use enough memory to store all metadata the crawler needs. In case of Redis
-running out of memory, the crawler will log this and continue. When the crawler is unable to write metadata to the
-database; that metadata is lost.
+recommended to ensure Redis is allowed to use enough memory to store all data the crawler needs. In case of Redis
+running out of memory, the crawler will log this and continue. When the crawler is unable to write metadata or queue
+items to the database; that metadata or queue items are lost.
 
 In case of connection errors; the crawler will attempt to reconnect three times. If the third attempt at connecting
 to Redis fails, the worker will skip that Redis operation and continue operating.

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -60,7 +60,6 @@ class RedisOperation(object):
             try:
                 return getattr(self._connection, _api)(*args, **kwargs)
             except ConnectionError:
-                print('conn err')
                 self._logger.exception("Connection to Redis failed operation")
                 pause = timeout.next()
                 if pause is None:

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -157,7 +157,7 @@ class RedisQueue(Queue):
         to_remove = []
         start = 0
         last_start = -1
-        while (count < max_n_requests or len(queue) < min_hosts) and last_start < start :
+        while (count < max_n_requests or len(queue) < min_hosts) and last_start < start:
             last_start = start
             start, subset_count, max_host_items = self._get_items(
                 partition_id, start, now_ts, queue, max_requests_per_host, max_host_items, count,

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -30,7 +30,7 @@ FIELD_URL = b'url'
 Error handling:
 * On Connection error:
 ** Retry three times with increasing timout. 
-** Fail and report error if the third retry fails.
+** Skip the operation if the third retry fails.
 * On Response error:
 ** Report and continue.
 ** Reponse error is usually caused by Redis using all available memory. Ideally, Redis should have enough memory
@@ -109,10 +109,11 @@ class RedisQueue(Queue):
                     self._logger.exception("Connection to Redis failed when attempting to get more requests")
                     pause = timeout.next()
                     if pause == None:
-                        raise
+                        break
                     sleep(pause)
                 except ResponseError as e:
                     self._logger.exception("Writing to Redis failed when attempting to get more requests")
+                    break
 
         self._logger.debug("Finished: hosts {}, requests {}".format(len(queue.keys()), count))
 
@@ -138,10 +139,11 @@ class RedisQueue(Queue):
                     self._logger.exception("Connection to Redis failed when attempting to remove scheduled items")
                     pause = timeout.next()
                     if pause == None:
-                        raise
+                        break
                     sleep(pause)
                 except ResponseError as e:
                     self._logger.exception("Writing to Redis failed when attempting to remove scheduled items")
+                    break
         return results
 
     def schedule(self, batch):
@@ -198,17 +200,18 @@ class RedisQueue(Queue):
                 self._logger.exception("Connection to Redis failed when attempting to schedule items")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to schedule items")
+                break
 
     def count(self):
         timeout = _get_retry_timeouts()
         while True:
             try:
-                connection = StrictRedis(connection_pool=self._pool)
                 count = 0
+                connection = StrictRedis(connection_pool=self._pool)
                 for partition_id in self._partitions:
                     count += connection.zcard(partition_id)
                 break
@@ -216,10 +219,11 @@ class RedisQueue(Queue):
                 self._logger.exception("Connection to Redis failed when attempting to count items")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to count items")
+                break
         return count
 
     def frontier_start(self):
@@ -269,10 +273,11 @@ class RedisState(States):
                 self._logger.exception("Connection to Redis failed when attempting to flush cache")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to flush cache")
+                break
         if force_clear:
             self._logger.debug("Cache has %d requests, clearing" % len(self._cache))
             self._cache.clear()
@@ -300,10 +305,11 @@ class RedisState(States):
                 self._logger.exception("Connection to Redis failed when attempting to fetch fingerprints")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to fetch fingerprints")
+                break
 
     def frontier_start(self):
         pass
@@ -327,10 +333,11 @@ class RedisMetadata(Metadata):
                     self._logger.exception("Connection to Redis failed when attempting to flush database")
                     pause = timeout.next()
                     if pause == None:
-                        raise
+                        break
                     sleep(pause)
                 except ResponseError as e:
                     self._logger.exception("Writing to Redis failed when attempting to flush database")
+                    break
 
     @classmethod
     def timestamp(cls):
@@ -358,10 +365,11 @@ class RedisMetadata(Metadata):
                 self._logger.exception("Connection to Redis failed when attempting to add seeds")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to add seeds")
+                break
 
     def request_error(self, page, error):
         timeout = _get_retry_timeouts()
@@ -382,10 +390,11 @@ class RedisMetadata(Metadata):
                 self._logger.exception("Connection to Redis failed when attempting to write request error")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to write request error")
+                break
 
     def page_crawled(self, response):
         timeout = _get_retry_timeouts()
@@ -403,10 +412,11 @@ class RedisMetadata(Metadata):
                 self._logger.exception("Connection to Redis failed when attempting to write page crawled status")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to write page crawled status")
+                break
 
     def links_extracted(self, _, links):
         timeout = _get_retry_timeouts()
@@ -432,10 +442,11 @@ class RedisMetadata(Metadata):
                 self._logger.exception("Connection to Redis failed when attempting to write links extracted")
                 pause = timeout.next()
                 if pause == None:
-                    raise
+                    break
                 sleep(pause)
             except ResponseError as e:
                 self._logger.exception("Writing to Redis failed when attempting to write links extracted")
+                break
 
     def frontier_start(self):
         pass

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -26,6 +26,18 @@ FIELD_STATUS_CODE = b'status_code'
 FIELD_URL = b'url'
 
 
+"""
+Error handling:
+* On Connection error:
+** Retry three times with increasing timout. 
+** Fail and report error if the third retry fails.
+* On Response error:
+** Report and continue.
+** Reponse error is usually caused by Redis using all available memory. Ideally, Redis should have enough memory
+ for this not to happen. Still, if Redis is full, the rest of the crawler may continue and free up some space in 
+ Redis after a while.
+"""
+
 # Timeout generator with backoff until 60 seconds
 def _get_retry_timeouts():
     for timeout in [0, 10, 30]: yield timeout

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -32,7 +32,7 @@ class RedisQueue(Queue):
 
     def __init__(self, manager, pool, partitions, delete_all_keys=False):
         settings = manager.settings
-        codec_path = settings.get('BACKEND_CODEC')
+        codec_path = settings.get('REDIS_BACKEND_CODEC')
         encoder_cls = load_object(codec_path + ".Encoder")
         decoder_cls = load_object(codec_path + ".Decoder")
         self._encoder = encoder_cls(manager.request_model)

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -1,0 +1,387 @@
+# -*- coding: utf-8 -*-
+from collections import Iterable
+from datetime import datetime
+from frontera.utils.url import parse_domain_from_url_fast
+from frontera import DistributedBackend
+from frontera.core.components import Metadata, Queue, States
+from frontera.core.models import Request
+from frontera.contrib.backends.partitioners import Crc32NamePartitioner
+from frontera.utils.misc import get_crc32
+from frontera.contrib.backends.remote.codecs.msgpack import Decoder, Encoder
+import logging
+from msgpack import packb, unpackb
+from redis import ConnectionPool, StrictRedis
+from time import time
+
+FIELD_CRAWL_AT = b'crawl_at'
+FIELD_CREATED_AT = b'created_at'
+FIELD_DEPTH = b'depth'
+FIELD_DOMAIN = b'domain'
+FIELD_DOMAIN_FINGERPRINT = b'domain_fingerprint'
+FIELD_ERROR = b'error'
+FIELD_FINGERPRINT = b'fingerprint'
+FIELD_NAME = b'name'
+FIELD_SCORE = b'score'
+FIELD_STATE = b'state'
+FIELD_STATUS_CODE = b'status_code'
+FIELD_URL = b'url'
+
+logging.getLogger('boto3.resources.action').setLevel(logging.WARNING)
+
+
+class RedisQueue(Queue):
+    MAX_SCORE = 1.0
+    MIN_SCORE = 0.0
+    SCORE_STEP = 0.01
+
+    def __init__(self, pool, partitions, delete_all_keys=False):
+        self._pool = pool
+        self._partitions = [i for i in range(0, partitions)]
+        self._partitioner = Crc32NamePartitioner(self._partitions)
+        self._logger = logging.getLogger("redis.queue")
+
+        if delete_all_keys:
+            connection = StrictRedis(connection_pool=self._pool)
+            connection.flushdb()
+
+        class DumbResponse:
+            pass
+
+        self._decoder = Decoder(Request, DumbResponse)
+        self._encoder = Encoder(Request)
+
+    def get_next_requests(self, max_n_requests, partition_id, **kwargs):
+        """
+        Tries to get new batch from priority queue. It makes self.GET_RETRIES tries and stops, trying to fit all
+        parameters. Every new iteration evaluates a deeper batch. After batch is requested it is removed from the queue.
+        :param max_n_requests: maximum number of requests
+        :param partition_id: partition id to get batch from
+        :return: list of :class:`Request <frontera.core.models.Request>` objects.
+        """
+        min_requests = kwargs.pop('min_requests')
+        max_requests_per_host = kwargs.pop('max_requests_per_host')
+        assert (max_n_requests >= min_requests)
+        connection = StrictRedis(connection_pool=self._pool)
+        queue = {}
+        count = 0
+        now_ts = int(time())
+        max_host_items = 0
+        to_remove = []
+        for data in connection.zrevrange(partition_id, start=0, end=max_n_requests):
+            item = unpackb(data, use_list=False)
+            timestamp, fprint, host_crc32, _, score = item
+            if timestamp > now_ts:
+                continue
+            if host_crc32 not in queue:
+                queue[host_crc32] = []
+            if max_requests_per_host is not None and len(queue[host_crc32]) > max_requests_per_host:
+                continue
+            queue[host_crc32].append(item)
+            if len(queue[host_crc32]) > max_host_items:
+                max_host_items = len(queue[host_crc32])
+            count += 1
+            to_remove.append(data)
+
+            if count >= max_n_requests:
+                break
+
+        self._logger.debug("Finished: hosts {}, requests {}".format(len(queue.keys()), count))
+
+        results = []
+        for i in range(max_host_items):
+            for host_crc32, items in queue.items():
+                if len(items) <= i:
+                    continue
+                item = items[i]
+                (_, _, _, encoded, score) = item
+                to_remove.append(packb(item))
+                request = self._decoder.decode_request(encoded)
+                request.meta[FIELD_SCORE] = score
+                results.append(request)
+        if len(to_remove) > 0:
+            connection.zrem(partition_id, *to_remove)
+        return results
+
+    def schedule(self, batch):
+        to_schedule = dict()
+        now = int(time())
+        for fprint, score, request, schedule in batch:
+            if schedule:
+                # TODO: This is done by DomainMiddleware - RedisBackend should require DomainMiddleware
+                if FIELD_DOMAIN not in request.meta:
+                    _, hostname, _, _, _, _ = parse_domain_from_url_fast(request.url)
+                    if not hostname:
+                        self._logger.error("Can't get hostname for URL %s, fingerprint %s", request.url, fprint)
+                    request.meta[FIELD_DOMAIN] = {'name': hostname}
+                timestamp = request.meta[FIELD_CRAWL_AT] if FIELD_CRAWL_AT in request.meta else now
+                to_schedule.setdefault(timestamp, []).append((request, score))
+        for timestamp, batch in to_schedule.items():
+            self._schedule(batch, timestamp)
+
+    @classmethod
+    def get_interval_start(cls, score):
+        if score < cls.MIN_SCORE or score > cls.MAX_SCORE:
+            raise OverflowError
+        i = int(score / cls.SCORE_STEP)
+        if i % 10 == 0 and i > 0:
+            i -= 1  # last interval is inclusive from right
+        return i * cls.SCORE_STEP
+
+    def _schedule(self, batch, timestamp):
+        data = dict()
+        for request, score in batch:
+            domain = request.meta[FIELD_DOMAIN]
+            fingerprint = request.meta[FIELD_FINGERPRINT]
+            if type(domain) == dict:
+                partition_id = self._partitioner.partition(domain[FIELD_NAME], self._partitions)
+                host_crc32 = get_crc32(domain[FIELD_NAME])
+            elif type(domain) == int:
+                partition_id = self._partitioner.partition_by_hash(domain, self._partitions)
+                host_crc32 = domain
+            else:
+                raise TypeError("domain of unknown type.")
+            item = (timestamp, fingerprint, host_crc32, self._encoder.encode_request(request), score)
+            interval_start = self.get_interval_start(score)
+            data.setdefault(partition_id, []).extend([int(interval_start * 100), packb(item)])
+        connection = StrictRedis(connection_pool=self._pool)
+        pipe = connection.pipeline()
+        for key, items in data.items():
+            connection.zadd(key, *items)
+        pipe.execute()
+
+    def count(self):
+        connection = StrictRedis(connection_pool=self._pool)
+        count = 0
+        for partition_id in self._partitions:
+            count += connection.zcard(partition_id)
+        return count
+
+    def frontier_start(self):
+        pass
+
+    def frontier_stop(self):
+        pass
+
+
+class RedisState(States):
+    def __init__(self, pool, cache_size_limit):
+        self._pool = pool
+        self._cache = {}
+        self._cache_size_limit = cache_size_limit
+        self._logger = logging.getLogger("redis.states")
+
+    def update_cache(self, objs):
+        objs = objs if isinstance(objs, Iterable) else [objs]
+
+        def put(obj):
+            self._cache[obj.meta[FIELD_FINGERPRINT]] = obj.meta[FIELD_STATE]
+
+        [put(obj) for obj in objs]
+
+    def set_states(self, objs):
+        objs = objs if isinstance(objs, Iterable) else [objs]
+
+        def get(obj):
+            fprint = obj.meta[FIELD_FINGERPRINT]
+            obj.meta[FIELD_STATE] = self._cache[fprint] if fprint in self._cache else States.DEFAULT
+
+        [get(obj) for obj in objs]
+
+    def flush(self, force_clear):
+        if len(self._cache) > self._cache_size_limit:
+            force_clear = True
+        connection = StrictRedis(connection_pool=self._pool)
+        pipe = connection.pipeline()
+        for fprint, state in self._cache.items():
+            pipe.hmset(fprint, {FIELD_STATE: state})
+        pipe.execute()
+        if force_clear:
+            self._logger.debug("Cache has %d requests, clearing" % len(self._cache))
+            self._cache.clear()
+
+    def fetch(self, fingerprints):
+        to_fetch = [f for f in fingerprints if f not in self._cache]
+        self._logger.debug("cache size %s" % len(self._cache))
+        self._logger.debug("to fetch %d from %d" % (len(to_fetch), len(fingerprints)))
+        connection = StrictRedis(connection_pool=self._pool)
+        pipe = connection.pipeline()
+        for key in to_fetch:
+            pipe.hgetall(key)
+        responses = pipe.execute()
+        for index, key in enumerate(to_fetch):
+            response = responses[index]
+            if len(response) > 0 and FIELD_STATE in response:
+                self._cache[key] = response[FIELD_STATE]
+            else:
+                self._cache[key] = self.NOT_CRAWLED
+
+    def frontier_start(self):
+        pass
+
+    def frontier_stop(self):
+        self.flush(False)
+
+
+class RedisMetadata(Metadata):
+    def __init__(self, pool, delete_all_keys):
+        self._pool = pool
+        self._logger = logging.getLogger("redis.metadata")
+        if delete_all_keys:
+            connection = StrictRedis(connection_pool=self._pool)
+            connection.flushdb()
+
+    @classmethod
+    def timestamp(cls):
+        return str(datetime.utcnow().replace(microsecond=0))
+
+    def add_seeds(self, seeds):
+        connection = StrictRedis(connection_pool=self._pool)
+        pipe = connection.pipeline()
+        for seed in seeds:
+            pipe.hmset(
+                seed.meta[FIELD_FINGERPRINT],
+                {
+                    FIELD_URL: seed.url,
+                    FIELD_DEPTH: 0,
+                    FIELD_CREATED_AT: self.timestamp(),
+                    FIELD_DOMAIN_FINGERPRINT: seed.meta[FIELD_DOMAIN][FIELD_FINGERPRINT]
+                }
+            )
+        pipe.execute()
+
+    def request_error(self, page, error):
+        connection = StrictRedis(connection_pool=self._pool)
+        connection.hmset(
+            page.meta[FIELD_FINGERPRINT],
+            {
+                FIELD_URL: page.url,
+                FIELD_CREATED_AT: self.timestamp(),
+                FIELD_ERROR: error,
+                FIELD_DOMAIN_FINGERPRINT: page.meta[FIELD_DOMAIN][FIELD_FINGERPRINT]
+            }
+        )
+
+    def page_crawled(self, response):
+        connection = StrictRedis(connection_pool=self._pool)
+        connection.hmset(
+            response.meta[FIELD_FINGERPRINT],
+            {
+                FIELD_STATUS_CODE: response.status_code
+            }
+        )
+
+    def links_extracted(self, _, links):
+        links_processed = set()
+        connection = StrictRedis(connection_pool=self._pool)
+        for link in links:
+            link_fingerprint = link.meta[FIELD_FINGERPRINT]
+            if link_fingerprint in links_processed:
+                continue
+            connection.hmset(
+                link_fingerprint,
+                {
+                    FIELD_URL: link.url,
+                    FIELD_CREATED_AT: self.timestamp(),
+                    FIELD_DOMAIN_FINGERPRINT: link.meta[FIELD_DOMAIN][FIELD_FINGERPRINT]
+                }
+            )
+            links_processed.add(link_fingerprint)
+
+    def frontier_start(self):
+        pass
+
+    def frontier_stop(self):
+        pass
+
+
+class RedisBackend(DistributedBackend):
+    component_name = 'Redis Backend'
+
+    def __init__(self, manager):
+        self.manager = manager
+        self._logger = logging.getLogger("redis.backend")
+        settings = manager.settings
+        port = settings.get('REDIS_PORT')
+        host = settings.get('REDIS_HOST')
+        self._min_requests = settings.get('BC_MIN_REQUESTS')
+        self._min_hosts = settings.get('BC_MIN_HOSTS')
+        self._max_requests_per_host = settings.get('BC_MAX_REQUESTS_PER_HOST')
+
+        self.queue_partitions = settings.get('SPIDER_FEED_PARTITIONS')
+        self._logger.info("RedisBackend started with {} partitions".format(self.queue_partitions))
+        self.pool = ConnectionPool(host=host, port=port, db=0)
+        self._metadata = None
+        self._queue = None
+        self._states = None
+
+    @classmethod
+    def strategy_worker(cls, manager):
+        o = cls(manager)
+        settings = manager.settings
+        o._states = RedisState(o.pool, settings.get('REDIS_STATE_CACHE_SIZE_LIMIT'))
+        return o
+
+    @classmethod
+    def db_worker(cls, manager):
+        o = cls(manager)
+        settings = manager.settings
+        clear = settings.get('REDIS_DROP_ALL_TABLES')
+        o._queue = RedisQueue(o.pool, o.queue_partitions, delete_all_keys=clear)
+        o._metadata = RedisMetadata(
+            o.pool,
+            clear
+        )
+        return o
+
+    @property
+    def metadata(self):
+        return self._metadata
+
+    @property
+    def queue(self):
+        return self._queue
+
+    @property
+    def states(self):
+        return self._states
+
+    def frontier_start(self):
+        for component in [self.metadata, self.queue, self.states]:
+            if component:
+                component.frontier_start()
+
+    def frontier_stop(self):
+        for component in [self.metadata, self.queue, self.states]:
+            if component:
+                component.frontier_stop()
+        self.pool.disconnect()
+
+    def add_seeds(self, seeds):
+        self.metadata.add_seeds(seeds)
+
+    def page_crawled(self, response):
+        self.metadata.page_crawled(response)
+
+    def links_extracted(self, request, links):
+        self.metadata.links_extracted(request, links)
+
+    def request_error(self, page, error):
+        self.metadata.request_error(page, error)
+
+    def finished(self):
+        raise NotImplementedError
+
+    def get_next_requests(self, max_next_requests, **kwargs):
+        next_pages = []
+        self._logger.debug("Querying queue table.")
+        partitions = set(kwargs.pop('partitions', []))
+        for partition_id in range(0, self.queue_partitions):
+            if partition_id not in partitions:
+                continue
+            results = self.queue.get_next_requests(max_next_requests, partition_id,
+                                                   min_requests=self._min_requests,
+                                                   min_hosts=self._min_hosts,
+                                                   max_requests_per_host=self._max_requests_per_host)
+            next_pages.extend(results)
+            self._logger.debug("Got %d requests for partition id %d", len(results), partition_id)
+        return next_pages

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -36,7 +36,7 @@ class RedisQueue(Queue):
         self._pool = pool
         self._partitions = [i for i in range(0, partitions)]
         self._partitioner = Crc32NamePartitioner(self._partitions)
-        self._logger = logging.getLogger("redis.queue")
+        self._logger = logging.getLogger("redis_backend.queue")
 
         if delete_all_keys:
             connection = StrictRedis(connection_pool=self._pool)
@@ -163,7 +163,7 @@ class RedisState(States):
         self._pool = pool
         self._cache = {}
         self._cache_size_limit = cache_size_limit
-        self._logger = logging.getLogger("redis.states")
+        self._logger = logging.getLogger("redis_backend.states")
 
     def update_cache(self, objs):
         objs = objs if isinstance(objs, Iterable) else [objs]
@@ -220,7 +220,7 @@ class RedisState(States):
 class RedisMetadata(Metadata):
     def __init__(self, pool, delete_all_keys):
         self._pool = pool
-        self._logger = logging.getLogger("redis.metadata")
+        self._logger = logging.getLogger("redis_backend.metadata")
         if delete_all_keys:
             connection = StrictRedis(connection_pool=self._pool)
             connection.flushdb()
@@ -294,7 +294,7 @@ class RedisBackend(DistributedBackend):
 
     def __init__(self, manager):
         self.manager = manager
-        self._logger = logging.getLogger("redis.backend")
+        self._logger = logging.getLogger("redis_backend.backend")
         settings = manager.settings
         port = settings.get('REDIS_PORT')
         host = settings.get('REDIS_HOST')

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -29,12 +29,12 @@ FIELD_URL = b'url'
 """
 Error handling:
 * On Connection error:
-** Retry three times with increasing timeout. 
+** Retry three times with increasing timeout.
 ** Skip the operation if the third retry fails.
 * On Response error:
 ** Report and continue.
 ** Response error is usually caused by Redis using all available memory. Ideally, Redis should have enough memory
- for this not to happen. Still, if Redis is full, the rest of the crawler may continue and free up some space in 
+ for this not to happen. Still, if Redis is full, the rest of the crawler may continue and free up some space in
  Redis after a while.
 """
 

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -367,9 +367,7 @@ class RedisBackend(DistributedBackend):
         next_pages = []
         self._logger.debug("Querying queue table.")
         partitions = set(kwargs.pop('partitions', []))
-        for partition_id in range(0, self.queue_partitions):
-            if partition_id not in partitions:
-                continue
+        for partition_id in partitions:
             results = self.queue.get_next_requests(max_next_requests, partition_id,
                                                    min_hosts=self._min_hosts,
                                                    max_requests_per_host=self._max_requests_per_host)

--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -72,7 +72,8 @@ class RedisOperation(object):
 
 class RedisPipeline(object):
     def __init__(self, pool):
-        self._pipeline = self._connection.pipeline()
+        connection = StrictRedis(connection_pool=pool)
+        self._pipeline = connection.pipeline()
         self._logger = logging.getLogger("redis_backend.RedisPipeline")
 
     def __getattr__(self, _api):

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 AUTO_START = True
 BACKEND = 'frontera.contrib.backends.memory.FIFO'
+BACKEND_CODEC = 'frontera.contrib.backends.remote.codecs.msgpack'
 BC_MIN_REQUESTS = 64
 BC_MIN_HOSTS = 24
 BC_MAX_REQUESTS_PER_HOST = 128

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 AUTO_START = True
 BACKEND = 'frontera.contrib.backends.memory.FIFO'
-BACKEND_CODEC = 'frontera.contrib.backends.remote.codecs.msgpack'
 BC_MIN_REQUESTS = 64
 BC_MIN_HOSTS = 24
 BC_MAX_REQUESTS_PER_HOST = 128
@@ -33,6 +32,7 @@ MIDDLEWARES = [
 NEW_BATCH_DELAY = 30.0
 OVERUSED_SLOT_FACTOR = 5.0
 QUEUE_HOSTNAME_PARTITIONING = False
+REDIS_BACKEND_CODEC = 'frontera.contrib.backends.remote.codecs.msgpack'
 REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
 REQUEST_MODEL = 'frontera.core.models.Request'

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -33,6 +33,8 @@ MIDDLEWARES = [
 NEW_BATCH_DELAY = 30.0
 OVERUSED_SLOT_FACTOR = 5.0
 QUEUE_HOSTNAME_PARTITIONING = False
+REDIS_HOST = 'localhost'
+REDIS_PORT = 6379
 REQUEST_MODEL = 'frontera.core.models.Request'
 RESPONSE_MODEL = 'frontera.core.models.Response'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 six>=1.8.0
 w3lib>=1.15.0
-redis>=2.10.5
-hiredis>=0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 six>=1.8.0
 w3lib>=1.15.0
+redis>=2.10.5
+hiredis>=0.2

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -13,3 +13,5 @@ happybase>=1.0.0
 mock
 boto>=2.42.0
 -r logging.txt
+redis>=2.10.5
+hiredis>=0.2x

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -14,4 +14,4 @@ mock
 boto>=2.42.0
 -r logging.txt
 redis>=2.10.5
-hiredis>=0.2x
+hiredis>=0.2

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,10 @@ setup(
         ],
         'distributed': [
             'Twisted'
+        ],
+        'redis': [
+            'redis>=2.10.5',
+            'hiredis>=0.2'
         ]
     },
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,8 @@ setup(
         "mock",
         "boto>=2.42.0",
         "colorlog>=2.4.0",
-        "python-json-logger>=0.1.5"
+        "python-json-logger>=0.1.5",
+        "redis>=2.10.5",
+        "hiredis>=0.2"
     ]
 )

--- a/tests/contrib/backends/redis_backend/test_redis.py
+++ b/tests/contrib/backends/redis_backend/test_redis.py
@@ -24,7 +24,7 @@ class Request:
 
 
 def get_pool():
-    port = 9763
+    port = 6379
     host = 'localhost'
     return ConnectionPool(host=host, port=port, db=0)
 

--- a/tests/contrib/backends/redis_backend/test_redis.py
+++ b/tests/contrib/backends/redis_backend/test_redis.py
@@ -301,6 +301,20 @@ class RedisQueueTest(TestCase):
         self.assertTrue('https://www.knuthellan.com/a' in urls)
         self.assertFalse('https://www.knuthellan.com/c' in urls)
 
+    def test_get_next_requests_few_items_few_hosts(self):
+        subject = self.setup_subject(2)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True)
+        ]
+        subject.schedule(batch)
+        self.assertEqual(1, subject.count())
+        requests = subject.get_next_requests(1, partition_id=0, min_hosts=2, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+        self.assertEqual(0, subject.count())
+
+
 
 class RedisStateTest(TestCase):
     def test_update_cache(self):

--- a/tests/contrib/backends/redis_backend/test_redis.py
+++ b/tests/contrib/backends/redis_backend/test_redis.py
@@ -1,0 +1,375 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from frontera.contrib.backends.redis_backend import FIELD_DOMAIN_FINGERPRINT, FIELD_ERROR, FIELD_STATE
+from frontera.contrib.backends.redis_backend import FIELD_STATUS_CODE, FIELD_URL
+from frontera.contrib.backends.redis_backend import RedisMetadata, RedisQueue, RedisState
+from redis import ConnectionPool, StrictRedis
+from time import time
+from unittest import main, TestCase
+
+
+class Request:
+    def __init__(self, fingerprint, crawl_at, url, domain=None):
+        self.meta = {
+            b'crawl_at': crawl_at,
+            b'fingerprint': fingerprint
+        }
+        if domain:
+            self.meta[b'domain'] = {b'name': domain, b'fingerprint': "d_{}".format(fingerprint)}
+        self.url = url
+        self.method = 'https'
+        self.headers = {}
+        self.cookies = None
+        self.status_code = 200
+
+
+def get_pool():
+    port = 32768
+    host = '192.168.99.100'
+    return ConnectionPool(host=host, port=port, db=0)
+
+
+class RedisQueueTest(TestCase):
+    def setup_subject(self, partitions):
+        return RedisQueue(get_pool(), partitions, True)
+
+    def test_scheduling_past_1part_5(self):
+        subject = self.setup_subject(1)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+        requests = subject.get_next_requests(5, 0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(3, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+        self.assertTrue('https://www.hellan.me/' in urls)
+        self.assertTrue('https://www.khellan.com/' in urls)
+        self.assertEqual(0, subject.count())
+
+    def test_scheduling_past_1part_1(self):
+        subject = self.setup_subject(1)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+        requests = subject.get_next_requests(1, 0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+        self.assertEqual(2, subject.count())
+
+    def test_scheduling_past_1part_2(self):
+        subject = self.setup_subject(1)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+        requests = subject.get_next_requests(2, 0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(2, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+        self.assertTrue('https://www.hellan.me/' in urls)
+        self.assertEqual(1, subject.count())
+
+    def test_scheduling_past_2part_5(self):
+        subject = self.setup_subject(2)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+
+        requests = subject.get_next_requests(5, partition_id=0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(2, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+        self.assertTrue('https://www.khellan.com/' in urls)
+        self.assertEqual(1, subject.count())
+
+        requests = subject.get_next_requests(5, partition_id=1, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.hellan.me/' in urls)
+        self.assertEqual(0, subject.count())
+
+    def test_scheduling_past_2part_2(self):
+        subject = self.setup_subject(2)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+        requests = subject.get_next_requests(2, partition_id=0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(2, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+        self.assertTrue('https://www.khellan.com/' in urls)
+        self.assertEqual(1, subject.count())
+
+        requests = subject.get_next_requests(2, partition_id=1, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.hellan.me/' in urls)
+        self.assertEqual(0, subject.count())
+
+    def test_scheduling_past_2part_1(self):
+        subject = self.setup_subject(2)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+        requests = subject.get_next_requests(1, partition_id=0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+
+        requests = subject.get_next_requests(1, partition_id=1, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.hellan.me/' in urls)
+        self.assertEqual(1, subject.count())
+
+    def test_scheduling_past_2part_multiple(self):
+        subject = self.setup_subject(2)
+        batch = [
+            ("1", 1, Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+
+        requests = subject.get_next_requests(1, partition_id=0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.knuthellan.com/' in urls)
+        self.assertEqual(2, subject.count())
+
+        requests = subject.get_next_requests(1, partition_id=1, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.hellan.me/' in urls)
+        self.assertEqual(1, subject.count())
+
+        requests = subject.get_next_requests(1, partition_id=0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.khellan.com/' in urls)
+        self.assertEqual(0, subject.count())
+
+        requests = subject.get_next_requests(1, partition_id=1, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(0, len(requests))
+
+        requests = subject.get_next_requests(1, partition_id=0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(0, len(requests))
+
+    def test_scheduling_future(self):
+        subject = self.setup_subject(1)
+        batch = [
+            ("1", 1, Request("1", int(time()) + 86400, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) + 86400, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) + 86400, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+
+        requests = subject.get_next_requests(5, 0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(0, len(requests))
+
+    def test_scheduling_mix(self):
+        subject = self.setup_subject(1)
+        batch = [
+            ("1", 1, Request("1", int(time()) + 86400, 'https://www.knuthellan.com/', domain='knuthellan.com'), True),
+            ("2", 0.1, Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com'), True),
+            ("3", 0.5, Request("3", int(time()) + 86400, 'https://www.hellan.me/', domain='hellan.me'), True),
+        ]
+        subject.schedule(batch)
+        self.assertEqual(3, subject.count())
+
+        requests = subject.get_next_requests(5, 0, min_hosts=1, min_requests=1, max_requests_per_host=5)
+        self.assertEqual(1, len(requests))
+        urls = [request.url for request in requests]
+        self.assertTrue('https://www.khellan.com/' in urls)
+        self.assertEqual(2, subject.count())
+
+
+class RedisStateTest(TestCase):
+    def test_update_cache(self):
+        subject = RedisState(get_pool(), 10)
+        r1 = Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r1.meta[b'state'] = b'a'
+        r2 = Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r2.meta[b'state'] = b'b'
+        r3 = Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        r3.meta[b'state'] = b'c'
+        batch = [r1, r2, r3]
+        subject.update_cache(batch)
+        self.assertEqual(3, len(subject._cache))
+        self.assertEqual(b'a', subject._cache["1"])
+        self.assertEqual(b'b', subject._cache["2"])
+        self.assertEqual(b'c', subject._cache["3"])
+
+    def test_set_states(self):
+        subject = RedisState(get_pool(), 10)
+        r1 = Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r1.meta[b'state'] = b'a'
+        r2 = Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r2.meta[b'state'] = b'b'
+        r3 = Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        r3.meta[b'state'] = b'c'
+        batch = [r1, r2, r3]
+        subject.update_cache(batch)
+        r4 = Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r5 = Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r6 = Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        batch2 = [r4, r5, r6]
+        subject.set_states(batch2)
+        self.assertEqual(b'a', r4.meta[b'state'])
+        self.assertEqual(b'b', r5.meta[b'state'])
+        self.assertEqual(b'c', r6.meta[b'state'])
+
+    def test_flush_no_force(self):
+        pool = get_pool()
+        subject = RedisState(pool, 10)
+        r1 = Request("1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r1.meta[b'state'] = b'a'
+        r2 = Request("2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r2.meta[b'state'] = b'b'
+        r3 = Request("3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        r3.meta[b'state'] = b'c'
+        batch = [r1, r2, r3]
+        subject.update_cache(batch)
+        subject.flush(False)
+        self.assertEqual(3, len(subject._cache))
+        connection = StrictRedis(connection_pool=pool)
+        self.assertEqual({FIELD_STATE: b'a'}, connection.hgetall("1"))
+        self.assertEqual({FIELD_STATE: b'b'}, connection.hgetall("2"))
+        self.assertEqual({FIELD_STATE: b'c'}, connection.hgetall("3"))
+
+    def test_flush_force(self):
+        pool = get_pool()
+        subject = RedisState(pool, 10)
+        r1 = Request("4", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r1.meta[b'state'] = b'd'
+        r2 = Request("5", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r2.meta[b'state'] = b'e'
+        r3 = Request("6", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        r3.meta[b'state'] = b'f'
+        batch = [r1, r2, r3]
+        subject.update_cache(batch)
+        subject.flush(True)
+        self.assertEqual(0, len(subject._cache))
+        connection = StrictRedis(connection_pool=pool)
+        self.assertEqual({FIELD_STATE: b'd'}, connection.hgetall("4"))
+        self.assertEqual({FIELD_STATE: b'e'}, connection.hgetall("5"))
+        self.assertEqual({FIELD_STATE: b'f'}, connection.hgetall("6"))
+
+    def test_flush_cache_overflow(self):
+        pool = get_pool()
+        subject = RedisState(pool, 1)
+        r1 = Request("4", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r1.meta[b'state'] = b'd'
+        r2 = Request("5", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r2.meta[b'state'] = b'e'
+        r3 = Request("6", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        r3.meta[b'state'] = b'f'
+        batch = [r1, r2, r3]
+        subject.update_cache(batch)
+        subject.flush(False)
+        self.assertEqual(0, len(subject._cache))
+        connection = StrictRedis(connection_pool=pool)
+        self.assertEqual({FIELD_STATE: b'd'}, connection.hgetall("4"))
+        self.assertEqual({FIELD_STATE: b'e'}, connection.hgetall("5"))
+        self.assertEqual({FIELD_STATE: b'f'}, connection.hgetall("6"))
+
+    def test_fetch(self):
+        subject = RedisState(get_pool(), 1)
+        r1 = Request("7", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r1.meta[b'state'] = b'g'
+        r2 = Request("8", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r2.meta[b'state'] = b'h'
+        batch = [r1, r2]
+        subject.update_cache(batch)
+        subject.flush(True)
+        r3 = Request("9", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        r3.meta[b'state'] = b'i'
+        subject.update_cache(r3)
+        self.assertEqual(1, len(subject._cache))
+        to_fetch = ["7", "9"]
+        subject.fetch(to_fetch)
+        self.assertEqual(2, len(subject._cache))
+        self.assertEqual(b'g', subject._cache["7"])
+        self.assertEqual(b'i', subject._cache["9"])
+
+
+class RedisMetadataTest(TestCase):
+    def test_add_seeds(self):
+        pool = get_pool()
+        subject = RedisMetadata(pool, True)
+        r1 = Request("md1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        r2 = Request("md2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        r3 = Request("md3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        seeds = [r1, r2, r3]
+        subject.add_seeds(seeds)
+        connection = StrictRedis(connection_pool=pool)
+        self.assertEqual(b'https://www.knuthellan.com/', connection.hmget('md1', FIELD_URL)[0])
+        self.assertEqual(b'd_md1', connection.hmget('md1', FIELD_DOMAIN_FINGERPRINT)[0])
+        self.assertEqual(b'https://www.khellan.com/', connection.hmget("md2", FIELD_URL)[0])
+        self.assertEqual(b'd_md2', connection.hmget('md2', FIELD_DOMAIN_FINGERPRINT)[0])
+        self.assertEqual(b'https://www.hellan.me/', connection.hmget("md3", FIELD_URL)[0])
+        self.assertEqual(b'd_md3', connection.hmget('md3', FIELD_DOMAIN_FINGERPRINT)[0])
+
+    def test_request_error(self):
+        pool = get_pool()
+        subject = RedisMetadata(pool, True)
+        r1 = Request("md1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        subject.request_error(r1, 404)
+        connection = StrictRedis(connection_pool=pool)
+        self.assertEqual(b'https://www.knuthellan.com/', connection.hmget('md1', FIELD_URL)[0])
+        self.assertEqual(b'd_md1', connection.hmget('md1', FIELD_DOMAIN_FINGERPRINT)[0])
+        self.assertEqual(b'404', connection.hmget('md1', FIELD_ERROR)[0])
+
+    def test_page_crawled(self):
+        pool = get_pool()
+        subject = RedisMetadata(pool, True)
+        r1 = Request("md1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        subject.page_crawled(r1)
+        connection = StrictRedis(connection_pool=pool)
+        self.assertEqual(b'200', connection.hmget('md1', FIELD_STATUS_CODE)[0])
+
+    def test_links_extracted(self):
+        pool = get_pool()
+        subject = RedisMetadata(pool, True)
+        l1 = Request("l1", int(time()) - 10, 'https://www.knuthellan.com/', domain='knuthellan.com')
+        l2 = Request("l2", int(time()) - 10, 'https://www.khellan.com/', domain='khellan.com')
+        l3 = Request("l3", int(time()) - 10, 'https://www.hellan.me/', domain='hellan.me')
+        links = [l1, l2, l3]
+        subject.links_extracted(None, links)
+        connection = StrictRedis(connection_pool=pool)
+        self.assertEqual(b'https://www.knuthellan.com/', connection.hmget('l1', FIELD_URL)[0])
+        self.assertEqual(b'd_l1', connection.hmget('l1', FIELD_DOMAIN_FINGERPRINT)[0])
+        self.assertEqual(b'https://www.khellan.com/', connection.hmget("l2", FIELD_URL)[0])
+        self.assertEqual(b'd_l2', connection.hmget('l2', FIELD_DOMAIN_FINGERPRINT)[0])
+        self.assertEqual(b'https://www.hellan.me/', connection.hmget("l3", FIELD_URL)[0])
+        self.assertEqual(b'd_l3', connection.hmget('l3', FIELD_DOMAIN_FINGERPRINT)[0])
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/contrib/backends/redis_backend/test_redis.py
+++ b/tests/contrib/backends/redis_backend/test_redis.py
@@ -9,6 +9,10 @@ from redis import ConnectionPool, StrictRedis
 from time import time
 from unittest import main, TestCase
 
+from logging import basicConfig, INFO
+
+basicConfig(level=INFO)
+
 
 class Request:
     def __init__(self, fingerprint, crawl_at, url, domain=None):
@@ -393,6 +397,7 @@ class RedisMetadataTest(TestCase):
         self.assertEqual(b'https://www.hellan.me/', connection.hmget("l3", FIELD_URL)[0])
         self.assertEqual(b'd_l3', connection.hmget('l3', FIELD_DOMAIN_FINGERPRINT)[0])
 
+
 class RedisBackendTest(TestCase):
     @staticmethod
     def setup_subject(partitions):
@@ -416,6 +421,7 @@ class RedisBackendTest(TestCase):
         subject.queue.schedule(batch)
         requests = subject.get_next_requests(max_next_requests=10, partitions=['0', '1'])
         self.assertEqual(3, len(requests))
+
 
 if __name__ == '__main__':
     main()

--- a/tests/contrib/backends/redis_backend/test_redis.py
+++ b/tests/contrib/backends/redis_backend/test_redis.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from frontera.contrib.backends.redis_backend import FIELD_DOMAIN_FINGERPRINT, FIELD_ERROR, FIELD_STATE
 from frontera.contrib.backends.redis_backend import FIELD_STATUS_CODE, FIELD_URL
 from frontera.contrib.backends.redis_backend import RedisMetadata, RedisQueue, RedisState
+from frontera.core.manager import FrontierManager
+from frontera.settings import Settings
 from redis import ConnectionPool, StrictRedis
 from time import time
 from unittest import main, TestCase
@@ -30,8 +32,10 @@ def get_pool():
 
 
 class RedisQueueTest(TestCase):
-    def setup_subject(self, partitions):
-        return RedisQueue(get_pool(), partitions, True)
+    @staticmethod
+    def setup_subject(partitions):
+        settings = Settings(module='frontera.settings.default_settings')
+        return RedisQueue(FrontierManager.from_settings(settings), get_pool(), partitions, True)
 
     def test_scheduling_past_1part_5(self):
         subject = self.setup_subject(1)

--- a/tests/contrib/backends/redis_backend/test_redis.py
+++ b/tests/contrib/backends/redis_backend/test_redis.py
@@ -24,8 +24,8 @@ class Request:
 
 
 def get_pool():
-    port = 32768
-    host = '192.168.99.100'
+    port = 9763
+    host = 'localhost'
     return ConnectionPool(host=host, port=port, db=0)
 
 


### PR DESCRIPTION
Add Redis backend modelled after the HBase backend.
This Backend is meant for use as a metadata store for frontera. Actual pages crawled
are assumed to be stored elsewhere using i.e. a pipeline.