### PR TITLE
Fix error raising in msgpack and json decoders

### DIFF
--- a/frontera/contrib/backends/remote/codecs/json.py
+++ b/frontera/contrib/backends/remote/codecs/json.py
@@ -190,7 +190,7 @@ class Decoder(json.JSONDecoder, BaseDecoder):
             return ('new_job_id', int(message['job_id']))
         if message['type'] == 'offset':
             return ('offset', int(message['partition_id']), int(message['offset']))
-        return TypeError('Unknown message type')
+        raise TypeError('Unknown message type')
 
     def decode_request(self, message):
         obj = _convert_from_saved_type(super(Decoder, self).decode(message))

--- a/frontera/contrib/backends/remote/codecs/msgpack.py
+++ b/frontera/contrib/backends/remote/codecs/msgpack.py
@@ -108,7 +108,7 @@ class Decoder(BaseDecoder):
             return ('new_job_id', int(obj[1]))
         if obj[0] == b'of':
             return ('offset', int(obj[1]), int(obj[2]))
-        return TypeError('Unknown message type')
+        raise TypeError('Unknown message type')
 
     def decode_request(self, buffer):
         return self._request_from_object(unpackb(buffer, encoding='utf-8'))


### PR DESCRIPTION
That's said. When upgrading from 0.7.0 to 0.7.1 my strategy/db workers went insane about not handled unknown message types coming from spiders.