### PR TITLE
Fix hostname local fingerprint from collisions

### DIFF
--- a/frontera/utils/fingerprint.py
+++ b/frontera/utils/fingerprint.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 import hashlib
-from six.moves.urllib.parse import urlparse
 from struct import pack
 from binascii import hexlify
 from frontera.utils.misc import get_crc32
 from frontera.utils.url import parse_url
-from w3lib.util import to_native_str, to_bytes
+from w3lib.util import to_bytes
 
 
 def sha1(key):
@@ -27,12 +26,11 @@ def hostname_local_fingerprint(key):
     :return: str 20 bytes hex string
     """
     result = parse_url(key)
-    if not result.hostname:
-        return sha1(key)
-    host_checksum = get_crc32(result.hostname)
-    doc_uri_combined = result.path+';'+result.params+result.query+result.fragment
+    hostname = result.hostname if result.hostname else '-'
+    host_checksum = get_crc32(hostname)
+    combined = hostname+result.path+';'+result.params+result.query+result.fragment
 
-    doc_uri_combined = to_bytes(doc_uri_combined, 'utf8', 'ignore')
-    doc_fprint = hashlib.md5(doc_uri_combined).digest()
+    combined = to_bytes(combined, 'utf8', 'ignore')
+    doc_fprint = hashlib.md5(combined).digest()
     fprint = hexlify(pack(">i16s", host_checksum, doc_fprint))
     return fprint

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -32,11 +32,11 @@ class TestFingerprint(object):
         assert md5(url3) == b'5abf5c9aa02d870756032bdec0bd6522'
 
     def test_local_hostname_fingerprint_bytes(self):
-        assert hostname_local_fingerprint(to_bytes(url1)) == b'1be68ff556fd0bbe5802d1a100850da29f7f15b1'
-        assert hostname_local_fingerprint(to_bytes(url2)) == b'd598b03bee8866ae03b54cb6912efdfef107fd6d'
-        assert hostname_local_fingerprint(to_bytes(url3)) == b'2ed642bbdf514b8520ab28f5da589ab28eda10a6'
+        assert hostname_local_fingerprint(to_bytes(url1)) == b'1be68ff5587d241e22865288133b37d63ab49e13'
+        assert hostname_local_fingerprint(to_bytes(url2)) == b'97ddb3f898d2460d60d3f4d6cb7dbc5d0b8025f8'
+        assert hostname_local_fingerprint(to_bytes(url3)) == b'2ed642bb1e215e68ef283a1939252734e84c3c76'
 
     def test_local_hostname_frongerprint_unicode(self):
-        assert hostname_local_fingerprint(url1) == b'1be68ff556fd0bbe5802d1a100850da29f7f15b1'
-        assert hostname_local_fingerprint(url2) == b'd598b03bee8866ae03b54cb6912efdfef107fd6d'
-        assert hostname_local_fingerprint(url3) == b'2ed642bbdf514b8520ab28f5da589ab28eda10a6'
+        assert hostname_local_fingerprint(url1) == b'1be68ff5587d241e22865288133b37d63ab49e13'
+        assert hostname_local_fingerprint(url2) == b'97ddb3f898d2460d60d3f4d6cb7dbc5d0b8025f8'
+        assert hostname_local_fingerprint(url3) == b'2ed642bb1e215e68ef283a1939252734e84c3c76'


### PR DESCRIPTION
adding hostname to md5 part
(continuation of #277)