### PR TITLE
Mark partition as busy when a new batch is sent to it

### DIFF
--- a/frontera/contrib/messagebus/kafkabus.py
+++ b/frontera/contrib/messagebus/kafkabus.py
@@ -131,6 +131,9 @@ class KeyedProducer(BaseStreamProducer):
     def get_offset(self, partition_id):
         pass
 
+    def partition(self, key):
+        return self._partitioner(key)
+
 
 class SpiderLogStream(BaseSpiderLogStream):
     def __init__(self, messagebus):

--- a/frontera/core/messagebus.py
+++ b/frontera/core/messagebus.py
@@ -67,6 +67,13 @@ class BaseStreamProducer(object):
         """
         raise NotImplementedError
 
+    def partition(self, key):
+        """
+        Returns partition id for key.
+        :param key: str key used for partitioning, None for non-keyed channels
+        """
+        raise NotImplementedError
+
     def close(self):
         """
         Performs all necessary cleanup and closes the producer.

--- a/tests/mocks/message_bus.py
+++ b/tests/mocks/message_bus.py
@@ -1,5 +1,5 @@
 from frontera.core.messagebus import BaseMessageBus, BaseSpiderLogStream, BaseStreamConsumer, \
-    BaseScoringLogStream, BaseSpiderFeedStream
+    BaseScoringLogStream, BaseSpiderFeedStream, BaseStreamProducer
 
 
 class Consumer(BaseStreamConsumer):
@@ -27,7 +27,7 @@ class Consumer(BaseStreamConsumer):
         return self.offset
 
 
-class Producer(object):
+class Producer(BaseStreamProducer):
 
     def __init__(self):
         self.messages = []
@@ -41,6 +41,9 @@ class Producer(object):
 
     def get_offset(self, partition_id):
         return self.offset
+
+    def partition(self, key):
+        return 0
 
 
 class ScoringLogStream(BaseScoringLogStream):


### PR DESCRIPTION
I happened to stumble onto this bug where the DBWorker keep sending request to the spider until the queue is empty. Seems to go as follow:

 2. DBWorker set Spider's partition as ready
 3. DBWorker send a new batch, `feed.counter = 256`
 4. Spider receive new batch, send new offset `spider.offset = 256`
 5. DBWorker receive offset, since `spider.offset <= feed.counter`, keep the partition as ready
 6. Spider is busy scraping.
 7. DBWorker send a new batch to the spider's partition, `feed.counter = 512`
 8. DBWorker still sending new batches, `feed.counter = 1024`
 9. Finally Spider has some space for new request, download next requests and then send its new offset, `spider.offset = 512`
10. DBWorker now set the partition as busy, however the lag between the spider offset and the feed counter can be quite huge by that time.

I guess crawling slowly make this worse since a single batch can take a few minutes to process, leaving the DBWorker some time to overload the feed.

My fix here is to mark a partition that received messages as busy. This way, the worker will wait for an update on the spider offset update to mark the partition as ready if needed. This should work well with a bigger `MAX_NEXT_REQUESTS` value on the worker to ensure the queue is never empty.

PS: Is there any IRC channel where the maintainers and other Frontera users are hanging out? I tried #scrapy but this didn't seem the right place to have Frontera discussion.