### PR TITLE
SSL support for Kafka message bus

### DIFF
--- a/docs/source/topics/frontera-settings.rst
+++ b/docs/source/topics/frontera-settings.rst
@@ -637,6 +637,24 @@ Default: ``None``
 Kafka-python 1.0.x version compression codec to use, is a string or None and could be one of ``snappy``, ``gzip`` or
 ``lz4``.
 
+.. setting:: KAFKA_ENABLE_SSL
+
+KAFKA_ENABLE_SSL
+----------------
+
+Default: ``False``
+
+Boolean to enable Kafka SSL authentication.
+
+.. setting:: KAFKA_CERT_PATH
+
+KAFKA_CERT_PATH
+---------------
+
+Default: ``None``
+
+OS path to a folder with SSL certificates.
+
 .. setting:: SPIDER_LOG_DBW_GROUP
 
 SPIDER_LOG_DBW_GROUP

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -78,3 +78,5 @@ SCORING_LOG_DBW_GROUP = "dbw-scoring-log"
 SPIDER_FEED_GROUP = "fetchers-spider-feed"
 
 KAFKA_CODEC = None
+KAFKA_CERT_PATH = None
+KAFKA_ENABLE_SSL = False


### PR DESCRIPTION
We have to provide SSL support for Kafka message bus, I believe it's nearly a requirement for production systems. However adding 2 additional Kafka params means enormous amount of "boilerplate" code if relying on current logic (the params should be added as attributes almost to each class in `kafkabus` module, it becomes clumsy). I'm proposing 2 things related with the SSL changes to relieve it:
- a small helper function to format SSLkwargs 
- a named tuple to store Kafka parameters common for all needs (location, codec, ssl-related settings)

The only downside is that it breaks backward-compatibility in a case if someone relies on Kafka consumer/producer classes defined in the module, but it should be OK as it's not a part of frontera public API. 

Tests are missing yet, but the changes are ready for initial review, please let me know if you disagree on start (and we revise the approach), or think it's appropriate changes and I'll continue with it.