### PR TITLE
Set overused factor so it actually trigger when a slot is full.

### DIFF
--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -30,7 +30,7 @@ MIDDLEWARES = [
     'frontera.contrib.middlewares.fingerprint.UrlFingerprintMiddleware',
 ]
 NEW_BATCH_DELAY = 30.0
-OVERUSED_SLOT_FACTOR = 5.0
+OVERUSED_SLOT_FACTOR = 1.0
 QUEUE_HOSTNAME_PARTITIONING = False
 REDIS_BACKEND_CODEC = 'frontera.contrib.backends.remote.codecs.msgpack'
 REDIS_HOST = 'localhost'


### PR DESCRIPTION
The settings is used to compare against: `overused_factor = len(slot.active) / float(slot.concurrency)`.
Unless I missed something, overused_factor is going to be between `[0..1]` and the following condition `overused_factor > self.frontier.manager.settings.get('OVERUSED_SLOT_FACTOR')` is never going to be `True` with a value of `5.0`. Setting a value of `1.0` at least start buffering when a slot is full.