### PR TITLE
Add max_queue_size to overused buffer to stop queue request when the …

### DIFF
--- a/docs/source/topics/frontera-settings.rst
+++ b/docs/source/topics/frontera-settings.rst
@@ -272,6 +272,16 @@ Default: ``5.0``
 (in progress + queued requests in that slot) / max allowed concurrent downloads per slot before slot is considered
 overused. This affects only Scrapy scheduler."
 
+.. setting:: OVERUSED_MAX_QUEUE_SIZE
+
+OVERUSED_MAX_QUEUE_SIZE
+--------------------
+
+Default: ``None``
+
+Max pending requests kept in the overused buffer for a slot. Use ``None`` or ``0`` to set no limit. Must be used with
+a queue backend that support spiders dropping requests.
+
 .. setting:: REQUEST_MODEL
 
 REQUEST_MODEL

--- a/frontera/contrib/backends/remote/messagebus.py
+++ b/frontera/contrib/backends/remote/messagebus.py
@@ -27,7 +27,8 @@ class MessageBusBackend(Backend):
         self._get_timeout = float(settings.get('KAFKA_GET_TIMEOUT'))
         self._logger = logging.getLogger("messagebus-backend")
         self._buffer = OverusedBuffer(self._get_next_requests,
-                                      self._logger.debug)
+                                      self._logger.debug,
+                                      settings.get('OVERUSED_MAX_QUEUE_SIZE'))
         self._logger.info("Consuming from partition id %d", self.partition_id)
 
     @classmethod

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -31,6 +31,7 @@ MIDDLEWARES = [
 ]
 NEW_BATCH_DELAY = 30.0
 OVERUSED_SLOT_FACTOR = 5.0
+OVERUSED_MAX_QUEUE_SIZE = None
 QUEUE_HOSTNAME_PARTITIONING = False
 REDIS_BACKEND_CODEC = 'frontera.contrib.backends.remote.codecs.msgpack'
 REDIS_HOST = 'localhost'

--- a/tests/test_core_overused_buffer.py
+++ b/tests/test_core_overused_buffer.py
@@ -10,6 +10,7 @@ r3 = Request('htttp://www.example.com/some/page/')
 r4 = Request('http://example.com')
 r5 = Request('http://example.com/some/page')
 r6 = Request('http://example1.com')
+r7 = Request('http://www.example.com/some/page/overflowing')
 
 
 class TestOverusedBuffer(object):
@@ -21,15 +22,15 @@ class TestOverusedBuffer(object):
         lst = []
         for _ in range(max_n_requests):
             if self.requests:
-                lst.append(self.requests.pop())
+                lst.append(self.requests.pop(0))
         return lst
 
     def log_func(self, msg):
         self.logs.append(msg)
 
     def test(self):
-        ob = OverusedBuffer(self.get_func, self.log_func)
-        self.requests = [r1, r2, r3, r4, r5, r6]
+        ob = OverusedBuffer(self.get_func, self.log_func, 3)
+        self.requests = [r1, r2, r3, r4, r5, r6, r7]
         assert set(ob.get_next_requests(10, overused_keys=['www.example.com', 'example1.com'],
                                         key_type='domain')) == set([r4, r5])
         assert set(self.logs) == set(["Overused keys: ['www.example.com', 'example1.com']",


### PR DESCRIPTION
…pending queue hit a size.

This prevent a single spider to buffer too many requests. Deactivated by default, must be used with backends that support spiders dropping requests.