### PR TITLE
Update hbase.py

### DIFF
--- a/frontera/contrib/backends/hbase.py
+++ b/frontera/contrib/backends/hbase.py
@@ -190,8 +190,8 @@ class HBaseQueue(Queue):
         :return: list of :class:`Request <frontera.core.models.Request>` objects.
         """
         min_requests = kwargs.pop('min_requests')
-        min_hosts = kwargs.pop('min_hosts')
-        max_requests_per_host = kwargs.pop('max_requests_per_host')
+        min_hosts = kwargs.pop('min_hosts', None)
+        max_requests_per_host = kwargs.pop('max_requests_per_host', None)
         assert(max_n_requests > min_requests)
         table = self.connection.table(self.table_name)
 


### PR DESCRIPTION
imho, in hbase queue's `get_next_requests` method,  params: min_hosts and max_requests_per_host are optional, because this method will check whether they are None, eg line no.225 and no.236, but kwargs.pop will raise Exception if I don't give these two params.