### PR TITLE
Update db.py

### DIFF
--- a/frontera/worker/db.py
+++ b/frontera/worker/db.py
@@ -76,7 +76,8 @@ class DBWorker(object):
         spider_log = self.mb.spider_log()
 
         self.spider_feed = self.mb.spider_feed()
-        self.spider_log_consumer = spider_log.consumer(partition_id=None, type=b'db')
+        if not no_incoming:
+            self.spider_log_consumer = spider_log.consumer(partition_id=None, type=b'db')
         self.spider_feed_producer = self.spider_feed.producer()
 
         self._manager = FrontierManager.from_settings(settings, db_worker=True)


### PR DESCRIPTION
if dbw is a `batch server` or `score log process server`, I mean this db process do not consume spider log topic, After add `no-incoming` flag to db launch command,  group `dbw-spider-log` always log 'Heartbeat session expired. so I add this condition to prevent init spider_log.consumer