### PR TITLE
update BCPerHostLimit in cluster example

### DIFF
--- a/examples/cluster/bc/broadcrawl/__init__.py
+++ b/examples/cluster/bc/broadcrawl/__init__.py
@@ -58,10 +58,6 @@ class BCPerHostLimit(BaseCrawlingStrategy):
         self.logger = logging.getLogger("bcperhostlimit-strategy")
         super(BCPerHostLimit, self).__init__(manager, mb_stream, states_context)
 
-    @classmethod
-    def from_worker(cls, manager, mb_scheduler, states_context):
-        return cls(manager, mb_scheduler, states_context)
-
     def add_seeds(self, seeds):
         self._schedule_and_count(seeds)
 


### PR DESCRIPTION
the `from_worker` method is duplicate , base class `BaseCrawlingStrategy` define `from_worker` already.