### PR TITLE
HBaseState flush when frontier stop

### DIFF
--- a/frontera/contrib/backends/hbase.py
+++ b/frontera/contrib/backends/hbase.py
@@ -297,7 +297,10 @@ class HBaseState(States):
             fprint = obj.meta[b'fingerprint']
             obj.meta[b'state'] = self._state_cache[fprint] if fprint in self._state_cache else States.DEFAULT
         [get(obj) for obj in objs]
-
+        
+    def frontier_stop(self):
+        self.flush(True)
+        
     def flush(self, force_clear):
         if len(self._state_cache) > self._cache_size_limit:
             force_clear = True


### PR DESCRIPTION
flush method in HBaseState invoked every 5 minutes by default settings to save cache state into meta table, add frontier_stop method to prevent state loss from memory cache dict when sw instance terminated.