### PR TITLE
Add support for “post requests and data” when integrating scrapy.

### DIFF
--- a/frontera/contrib/backends/remote/codecs/msgpack.py
+++ b/frontera/contrib/backends/remote/codecs/msgpack.py
@@ -32,12 +32,12 @@ def _prepare_request_message(request):
         else:
             logger.warning('unable to serialize object: {}'.format(obj))
             return None
-    return [request.url, request.method, request.headers, request.cookies, serialize(request.meta)]
+    return [request.url, request.method, request.headers, request.cookies, serialize(request.meta), request.body]
 
 
 def _prepare_response_message(response, send_body):
-    return [response.url, response.status_code, response.meta, response.headers, response.body if send_body else None]
-
+    return [response.url, response.status_code, response.meta, response.body if send_body else None
+                        , response.request.method, response.request.headers, response.request.cookies]
 
 class Encoder(BaseEncoder):
     def __init__(self, request_model, *a, **kw):
@@ -81,14 +81,18 @@ class Decoder(BaseDecoder):
                                     body=obj[4],
                                     headers=obj[3],
                                     request=self._request_model(url=url,
-                                                                meta=obj[2]))
+                                                                meta=obj[2],
+                                                                method=obj[4],
+                                                                headers=obj[5],
+                                                                cookies=obj[6]))
 
     def _request_from_object(self, obj):
         return self._request_model(url=to_native_str(obj[0]),
                                    method=obj[1],
                                    headers=obj[2],
                                    cookies=obj[3],
-                                   meta=obj[4])
+                                   meta=obj[4],
+                                   body=obj[5])
 
     def decode(self, buffer):
         obj = unpackb(buffer, encoding='utf-8')

--- a/frontera/contrib/backends/sqlalchemy/components.py
+++ b/frontera/contrib/backends/sqlalchemy/components.py
@@ -95,6 +95,7 @@ class Metadata(BaseMetadata):
             db_page.headers = obj.headers
             db_page.method = to_native_str(obj.method)
             db_page.cookies = obj.cookies
+            db_page.body=obj.body
         elif isinstance(obj, Response):
             db_page.headers = obj.request.headers
             db_page.method = to_native_str(obj.request.method)
@@ -177,7 +178,7 @@ class Queue(BaseQueue):
             for item in self._order_by(self.session.query(self.queue_model).filter_by(partition_id=partition_id)).\
                     limit(max_n_requests):
                 method = item.method or b'GET'
-                r = Request(item.url, method=method, meta=item.meta, headers=item.headers, cookies=item.cookies)
+                r = Request(item.url, method=method, meta=item.meta, headers=item.headers, cookies=item.cookies, body=item.body)
                 r.meta[b'fingerprint'] = to_bytes(item.fingerprint)
                 r.meta[b'score'] = item.score
                 results.append(r)
@@ -203,7 +204,7 @@ class Queue(BaseQueue):
                     host_crc32 = get_crc32(hostname)
                 q = self.queue_model(fingerprint=to_native_str(fprint), score=score, url=request.url, meta=request.meta,
                                      headers=request.headers, cookies=request.cookies, method=to_native_str(request.method),
-                                     partition_id=partition_id, host_crc32=host_crc32, created_at=time()*1E+6)
+                                     partition_id=partition_id, host_crc32=host_crc32, created_at=time()*1E+6, body=request.body)
                 to_save.append(q)
                 request.meta[b'state'] = States.QUEUED
         self.session.bulk_save_objects(to_save)

--- a/frontera/contrib/backends/sqlalchemy/models.py
+++ b/frontera/contrib/backends/sqlalchemy/models.py
@@ -26,6 +26,7 @@ class MetadataModel(DeclarativeBase):
     error = Column(String(128))
     meta = Column(PickleType())
     headers = Column(PickleType())
+    body = Column(PickleType())
     cookies = Column(PickleType())
     method = Column(String(6))
 
@@ -76,6 +77,7 @@ class QueueModelMixin(object):
     meta = Column(PickleType())
     headers = Column(PickleType())
     cookies = Column(PickleType())
+    body = Column(PickleType())
     method = Column(String(6))
     created_at = Column(BigInteger, index=True)
     depth = Column(SmallInteger)

--- a/frontera/contrib/backends/sqlalchemy/revisiting.py
+++ b/frontera/contrib/backends/sqlalchemy/revisiting.py
@@ -67,7 +67,7 @@ class RevisitingQueue(BaseQueue):
                     limit(max_n_requests):
                 method = 'GET' if not item.method else item.method
                 results.append(Request(item.url, method=method, meta=item.meta, headers=item.headers,
-                                       cookies=item.cookies))
+                                       cookies=item.cookies, body=item.body))
                 self.session.delete(item)
             self.session.commit()
         except Exception as exc:
@@ -92,7 +92,7 @@ class RevisitingQueue(BaseQueue):
                 q = self.queue_model(fingerprint=fprint, score=score, url=request.url, meta=request.meta,
                                      headers=request.headers, cookies=request.cookies, method=request.method,
                                      partition_id=partition_id, host_crc32=host_crc32, created_at=time()*1E+6,
-                                     crawl_at=schedule_at)
+                                     crawl_at=schedule_at, body=request.body)
                 to_save.append(q)
                 request.meta[b'state'] = States.QUEUED
         self.session.bulk_save_objects(to_save)


### PR DESCRIPTION
Add support for “post requests and data” when integrating scrapy.
Resolve the bug for “wrong request data in metadata” when response updates metadata.