### PR TITLE
Crash on closing redis backend, missing 'force_clear' argument

### DIFF
--- a/frontera/contrib/backends/redis_backend/__init__.py
+++ b/frontera/contrib/backends/redis_backend/__init__.py
@@ -258,7 +258,7 @@ class RedisState(States):
 
         [get(obj) for obj in objs]
 
-    def flush(self, force_clear):
+    def flush(self, force_clear=False):
         if len(self._cache) > self._cache_size_limit:
             force_clear = True
         [self._redis_pipeline.hmset(fprint, {FIELD_STATE: state}) for (fprint, state) in self._cache.items()]

--- a/frontera/settings/default_settings.py
+++ b/frontera/settings/default_settings.py
@@ -49,6 +49,7 @@ QUEUE_HOSTNAME_PARTITIONING = False
 REDIS_BACKEND_CODEC = 'frontera.contrib.backends.remote.codecs.msgpack'
 REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
+REDIS_STATE_CACHE_SIZE_LIMIT = 0
 REQUEST_MODEL = 'frontera.core.models.Request'
 RESPONSE_MODEL = 'frontera.core.models.Response'
 

--- a/tests/contrib/backends/redis_backend/test_redis.py
+++ b/tests/contrib/backends/redis_backend/test_redis.py
@@ -501,6 +501,13 @@ class RedisBackendTest(TestCase):
         requests = subject.get_next_requests(max_next_requests=10, partitions=['0', '1'])
         self.assertEqual(3, len(requests))
 
+    def test_close_manager(self):
+        settings = Settings(module='frontera.settings.default_settings')
+        settings.set('BACKEND', 'frontera.contrib.backends.redis_backend.RedisBackend')
+        manager = WorkerFrontierManager.from_settings(settings, strategy_worker=True)
+        self.assertEqual(RedisBackend, manager.backend.__class__)
+        manager.close()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Frontera is failing with the following error when using add_seeds with redis as the backend:
TypeError: flush() missing 1 required positional argument: 'force_clear'