### PR TITLE
Update cluster-setup docs

### DIFF
--- a/docs/source/topics/cluster-setup.rst
+++ b/docs/source/topics/cluster-setup.rst
@@ -88,7 +88,7 @@ a common modules and import settings from it in component's modules.
     from __future__ import absolute_import
     from .worker import *
 
-    CRAWLING_STRATEGY = '' # path to the crawling strategy class
+    STRATEGY = '' # path to the crawling strategy class
     LOGGING_CONFIG='logging-sw.conf' # if needed
 
 The logging can be configured according to https://docs.python.org/2/library/logging.config.html see the
@@ -127,7 +127,7 @@ First, let's start storage worker: ::
 
     # start DB worker only for batch generation
     # use single instance for every 10 partitions
-    $ python -m frontera.worker.db --config [db worker config module] --no-incoming --partitions 0,1
+    $ python -m frontera.worker.db --config [db worker config module] --no-incoming --partitions 0 1
 
 
     # Optionally, start next one dedicated to spider log processing.


### PR DESCRIPTION
Hello, I've been using frontera for the last couple of months and have found that in some places the docs are not up to date. In this case the setup-cluster docs.

If I try to run the dbworker as specified in the setup cluster doc on [line 130](https://github.com/scrapinghub/frontera/blob/master/docs/source/topics/cluster-setup.rst), by running:
 `python -m frontera.worker.db --config src.config.db_worker --no-scoring
      --no-incoming --partitions 0,1` 

I get the following output:
```dbworker_batch_1        | usage: db.py [-h] [--no-batches] [--no-incoming] [--no-scoring]
dbworker_batch_1        |              [--partitions [PARTITIONS [PARTITIONS ...]]] --config CONFIG
dbworker_batch_1        |              [--log-level LOG_LEVEL] [--port PORT]
dbworker_batch_1        | db.py: error: argument --partitions: invalid int value: '0,1'
```
By trial and error I found out that the current correct way to initialize the dbworker with a specific number of partitions is by running the following:
`python -m frontera.worker.db --config src.config.db_worker --no-scoring
      --no-incoming --partitions 0 1`

As well the `CRAWLING_STRATEGY` config var that is specified in the doc, on [line 91](https://github.com/scrapinghub/frontera/blob/master/docs/source/topics/cluster-setup.rst), if you config that var the specified crawling strategy is not taken into account by frontera. So I looked into the [default_settings](https://github.com/scrapinghub/frontera/blob/bd781e5e2b7f9347ad86beba53b4dedb33c63f14/frontera/settings/default_settings.py) file, on line 77, to see how to correctly set that var and there the var that does that is named `STRATEGY`. When I made that change the strategy started working as expected.

So to sum everything up, I've just updated the docs to reflect this changes.