### PR TITLE
Fix bug when ordering elements on queue when get next batch of requests

### DIFF
--- a/frontera/contrib/backends/sqlalchemy/components.py
+++ b/frontera/contrib/backends/sqlalchemy/components.py
@@ -164,7 +164,7 @@ class Queue(BaseQueue):
             return query.order_by(self.queue_model.created_at)
         if self.ordering == 'created_desc':
             return query.order_by(self.queue_model.created_at.desc())
-        return query.order_by(self.queue_model.score, self.queue_model.created_at)  # TODO: remove second parameter,
+        return query.order_by(self.queue_model.score.desc(), self.queue_model.created_at)  # TODO: remove second parameter,
         # it's not necessary for proper crawling, but needed for tests
 
     def get_next_requests(self, max_n_requests, partition_id, **kwargs):


### PR DESCRIPTION
I found that when using a MySQL database as backend the `queue` table was being consumed in the opposite order as intended (elements with lower priority were being consumed first).

I found that on the `queue` component the `_order_by` method had no default order condition, so I added an explicit `desc()` clause (elements with bigger priority first). I guess this can apply to other backends (Postgres).

Thanks!