### PR TITLE
Docs:  BaseCrawlingStrategy._refresh_states() also takes a non iterab…

### DIFF
--- a/frontera/strategy/__init__.py
+++ b/frontera/strategy/__init__.py
@@ -138,9 +138,10 @@ class BaseCrawlingStrategy(object):
 
     def refresh_states(self, requests):
         """
-        Retrieves states for all requests from storage.
-
-        :param requests: list(:class:`Request <frontera.core.models.Request>`)
+        Retrieves states for all requests from storage. Converts requests to a 1 item list() of :class:`Request <frontera.core.models.Request>` 
+        if requests is not a list of :class:`Request <frontera.core.models.Request>` objects.
+        
+        :param requests: list(:class:`Request <frontera.core.models.Request>`) or a single :class:`Request <frontera.core.models.Request>`
         """
         self._states_context.refresh_and_keep(requests)
 

--- a/frontera/strategy/__init__.py
+++ b/frontera/strategy/__init__.py
@@ -138,7 +138,7 @@ class BaseCrawlingStrategy(object):
 
     def refresh_states(self, requests):
         """
-        Retrieves states for all requests from storage. Converts requests to a 1 item list() of :class:`Request <frontera.core.models.Request>` 
+        Retrieves states for all requests from storage. ` 
         if requests is not a list of :class:`Request <frontera.core.models.Request>` objects.
         
         :param requests: list(:class:`Request <frontera.core.models.Request>`) or a single :class:`Request <frontera.core.models.Request>`


### PR DESCRIPTION
…le for the requests parameter.

It is important to disclose that `_refresh_states()` also takes a non iterable for the requests parameter. Eventually, `refresh_and_keep()` converts the non iterable object into a non-iterable object contained within a list.