### PR TITLE
Increase session.timeout.ms for KafkaConsumer

### DIFF
--- a/frontera/contrib/messagebus/kafkabus.py
+++ b/frontera/contrib/messagebus/kafkabus.py
@@ -50,6 +50,7 @@ class Consumer(BaseStreamConsumer):
             client_id="%s-%s" % (self._topic, str(partition_id) if partition_id is not None else "all"),
             request_timeout_ms=120 * 1000,
             heartbeat_interval_ms=10000,
+            session_timeout_ms= 10000 * 3
             **kwargs
         )
 


### PR DESCRIPTION
We found an issue where we were seeing duplicate messages on the bus and some warnings sent by Kafka.

The issue was that the consumers were disconnected and the messages were sent again. The `heartbeat_interval_ms` on the `KafkaConsumer` is tightly related to the `session_timeout_ms` and cannot be set randomly. If no heartbeat is sent before the session timeout occurs, the consumer is considered dead (and currently both are set to the same value, which will cause errors if the timeout occurs before the heartbeat).
As the documentation says https://kafka.apache.org/documentation/ on `heartbeat.interval.ms` the `heartbeat_interval_ms` has to be less than 1/3 of the `session_timeout_ms`. This PR introduces changes to take that into account.

It can be seen on the `kafka-python`  [repo](https://github.com/dpkp/kafka-python/blob/807ac8244cd39ca8426cfeda245ec27802c0a600/kafka/consumer/group.py#L138) that the default values take this into consideration.

Thanks!