### PR TITLE
Add 3.6 support in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,14 @@ matrix:
         - mysql
         - postgresql
         - redis-server
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      services:
+        - docker
+        - mysql
+        - postgresql
+        - redis-server
 
 install:
   - pip install -U tox wheel codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,6 @@ matrix:
         - mysql
         - postgresql
         - redis-server
-    - python: 3.7
-      env: TOXENV=py37
-      dist: xenial
-      services:
-        - docker
-        - mysql
-        - postgresql
-        - redis-server
 
 install:
   - pip install -U tox wheel codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,6 @@ matrix:
         - mysql
         - postgresql
         - redis-server
-    - python: 3.7
-      env: TOXENV=py37
-      services:
-        - docker
-        - mysql
-        - postgresql
-        - redis-server
 
 install:
   - pip install -U tox wheel codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,20 @@ matrix:
         - mysql
         - postgresql
         - redis-server
+    - python: 3.6
+      env: TOXENV=py36
+      services:
+        - docker
+        - mysql
+        - postgresql
+        - redis-server
+    - python: 3.7
+      env: TOXENV=py37
+      services:
+        - docker
+        - mysql
+        - postgresql
+        - redis-server
 
 install:
   - pip install -U tox wheel codecov

--- a/frontera/worker/stats.py
+++ b/frontera/worker/stats.py
@@ -51,7 +51,7 @@ class StatsExportMixin(object):
         - 'source' - source type of the metric, one of ['sw', 'dbw', 'spider']
         - 'partition_id' (optionally) - specific partition id
         """
-        raise NotImplemented("Please define the method in a child class")
+        raise NotImplementedError("Please define the method in a child class")
 
     @property
     def _stats_key_prefix(self):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
hi, I'm trying to learn about frontera and I hope this can be my a starting point of small contribution.

Currently in setup.py only python 3.5 is claim to be supported, I think we can add 3.6 too.

There are a few tests errors in travis ci, and I don't intent to fix them here - maybe for another pr - imo as long as there are same number of fails for python 3.5 and 3.6 then we're good.

Errors for py35 (build log https://travis-ci.com/lucywang000/frontera/jobs/180100043)
<img width="708" alt="errors-py35" src="https://user-images.githubusercontent.com/30067222/53301310-22af4700-388c-11e9-8cc8-a15a50faf547.png">

Errors for py36(build log https://travis-ci.com/lucywang000/frontera/jobs/180100044)
<img width="711" alt="errors-py36" src="https://user-images.githubusercontent.com/30067222/53301327-45416000-388c-11e9-998c-8adf37df2eab.png">


For 3.7 there is a problem: thriftpy can't install under 3.7, and that project is no longer maintained:
``` 
 thriftpy/transport/cybase.c:3192:11: error: ‘PyThreadState {aka struct _ts}’ has no member named ‘exc_traceback’
       tstate->exc_traceback = tb;
             ^
  error: command 'gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for thriftpy
```

but there is a new fork called thriftpy2 (see https://github.com/Yelp/py_zipkin/pull/115). This may also be the work of a separate pr.
