### PR TITLE
Move tox to test requirements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-branch = true
-source = frontera

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
         - redis-server
 
 install:
-  - pip install -U tox wheel codecov
+  - pip install -U wheel codecov
   - pip install -r requirements/tests.txt
 
 before_install:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,19 +1,21 @@
-flaky
-pytest>=2.6.4
-PyMySQL>=0.6.3
-psycopg2>=2.5.4
-scrapy>=0.24
--r tldextract.txt
-SQLAlchemy>=1.0.0
-cachetools
-pyzmq
-msgpack-python>=0.4
-kafka-python>=1.4.0
-pytest-cov
-happybase>=1.0.0
-mock
 boto>=2.42.0
--r logging.txt
-redis>=2.10.5
-hiredis>=0.2
+cachetools
 cityhash>=0.1.7
+flaky
+happybase>=1.0.0
+hiredis>=0.2
+kafka-python>=1.4.0
+mock
+msgpack-python>=0.4
+psycopg2>=2.5.4
+PyMySQL>=0.6.3
+pytest>=2.6.4
+pytest-cov
+pyzmq
+redis>=2.10.5
+scrapy>=0.24
+SQLAlchemy>=1.0.0
+tox
+
+-r logging.txt
+-r tldextract.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,3 @@ description-file = README.md
 branch = true
 source =
     frontera/
-omit =
-    *__init__*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [metadata]
 description-file = README.md
+
+[coverage:run]
+source =
+    frontera/
+omit =
+    *__init__*

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 description-file = README.md
 
 [coverage:run]
+branch = true
 source =
     frontera/
 omit =


### PR DESCRIPTION
- Sorted the test requirements to make it a bit easier to read
- Since we already have a `setup.cfg` file, move `.coveragerc` contents to it. I think since the `setup.cfg` file is there, coverage might've not even been reading the `.coveragerc` file, but I'm not sure. Either way, it's good to combine the files and move CI config settings all to one place