### PR TITLE
Add "make run" command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ services:
   - redis-server
 
 env:
-  global:
-    - DOCKER_COMPOSE_VERSION=1.7.1
   matrix:
     - TOXENV=py27
     - TOXENV=flake8
@@ -48,25 +46,14 @@ install:
   - pip install -r requirements/tests.txt
 
 before_install:
-  - sudo apt-get update
-  - sudo rm -f /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-  - git clone https://github.com/scrapinghub/hbase-docker.git
-  - docker pull scrapinghub/hbase-docker
-  - mkdir data
-  - ./hbase-docker/start-hbase.sh
+  - make run
 
 before_script:
   - mysql -u root -e "set global innodb_large_prefix=1;"
   - mysql -u root -e "set global innodb_file_format='Barracuda';"
   - mysql -u root -e "set global innodb_file_per_table=true;"
   - tests/run_zmq_broker.sh
-  - docker --version
-  - docker-compose --version
-  - docker-compose --verbose -f tests/kafka/docker-compose.yml up -d
-  - docker ps -a
+  - docker-compose up -d
 
 script: tox
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+run:
+	sudo docker-compose up -d
+	sudo docker pull dajobe/hbase
+	mkdir -p data
+	id=$(sudo docker run --name=hbase-docker -h hbase-docker -d -v $PWD/data:/data dajobe/hbase)
+	wget https://raw.githubusercontent.com/scrapinghub/hbase-docker/master/start-hbase.sh
+	chmod +x start-hbase.sh
+	sudo ./start-hbase.sh
+	rm start-hbase.sh

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ $ pip install frontera
 
 Join our Google group at https://groups.google.com/a/scrapinghub.com/forum/#!forum/frontera or check GitHub issues and 
 pull requests.
+
+## Development
+
+You can run Dockerized service dependencies for local development by running:
+
+```bash
+$ make run
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   zookeeper:
     image: wurstmeister/zookeeper


### PR DESCRIPTION
Makes for easier local development :slightly_smiling_face: 

- Add a `make run` command for easier local development
- Move the test docker-compose.yml file to the root directory (this is more standard)
- Bump docker-compose config version to 3 (latest is best if it works!)
- Remove installing a separate docker-compose version as it seems like the version included by Travis works for running tests
- Add note to README on new Makefile command for local development